### PR TITLE
Issue #23: Rename toSamples to toInstants

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2014, Cloudera, Inc. All Rights Reserved.
+  Copyright (c) 2015, Cloudera, Inc. All Rights Reserved.
 
   Cloudera, Inc. licenses this file to you under the Apache License,
   Version 2.0 (the "License"). You may not use this file except in
@@ -13,7 +13,9 @@
   the specific language governing permissions and limitations under the
   License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.cloudera.datascience</groupId>
   <artifactId>sparktimeseries</artifactId>

--- a/src/main/scala/com/cloudera/finance/examples/SimpleTickDataExample.scala
+++ b/src/main/scala/com/cloudera/finance/examples/SimpleTickDataExample.scala
@@ -71,6 +71,6 @@ object SimpleTickDataExample {
     val iidRdd = slicedRdd.mapSeries(series => ar(series, 1).removeTimeDependentEffects(series))
 
     // Regress a stock against all the others
-    val samples = iidRdd.toSamples()
+    val samples = iidRdd.toInstants()
   }
 }

--- a/src/main/scala/com/cloudera/sparkts/TimeSeriesRDD.scala
+++ b/src/main/scala/com/cloudera/sparkts/TimeSeriesRDD.scala
@@ -158,7 +158,7 @@ class TimeSeriesRDD(val index: DateTimeIndex, parent: RDD[(String, Vector[Double
    * In the returned RDD, the ordering of values within each record corresponds to the ordering of
    * the time series records in the original RDD. The records are ordered by time.
    */
-  def toSamples(nPartitions: Int = -1): RDD[(DateTime, Vector[Double])] = {
+  def toInstants(nPartitions: Int = -1): RDD[(DateTime, Vector[Double])] = {
     val maxChunkSize = 20
 
     val dividedOnMapSide = mapPartitionsWithIndex { case (partitionId, iter) =>

--- a/src/test/scala/com/cloudera/sparkts/TimeSeriesRDDSuite.scala
+++ b/src/test/scala/com/cloudera/sparkts/TimeSeriesRDDSuite.scala
@@ -60,7 +60,7 @@ class TimeSeriesRDDSuite extends FunSuite with LocalSparkContext with ShouldMatc
     rdd.filterEndingAfter(start).count() should be (3)
   }
 
-  test("toSamples") {
+  test("toInstants") {
     val conf = new SparkConf().setMaster("local").setAppName(getClass.getName)
     TimeSeriesKryoRegistrator.registerKryoClasses(conf)
     sc = new SparkContext(conf)
@@ -71,7 +71,7 @@ class TimeSeriesRDDSuite extends FunSuite with LocalSparkContext with ShouldMatc
     val index = uniform(start, 4, 1.days)
     val rdd = sc.parallelize(labels.zip(seriesVecs.map(_.asInstanceOf[Vector[Double]])), 3)
     val tsRdd = new TimeSeriesRDD(index, rdd)
-    val samples = tsRdd.toSamples().collect()
+    val samples = tsRdd.toInstants().collect()
     samples should be (Array(
       (start, new DenseVector((0.0 until 20.0 by 4.0).toArray)),
       (start + 1.days, new DenseVector((1.0 until 20.0 by 4.0).toArray)),


### PR DESCRIPTION
https://github.com/cloudera/spark-timeseries/issues/23

Quick find & replace. All tests are green locally.