### PR TITLE
added simple function to plot vectors of varying length

### DIFF
--- a/src/main/scala/com/cloudera/sparkts/EasyPlot.scala
+++ b/src/main/scala/com/cloudera/sparkts/EasyPlot.scala
@@ -50,7 +50,7 @@ object EasyPlot {
 
   /**
    * Plot multiple series of varying lengths, fills in shorter series with NaNs for plotting.
-   * Useful for plotting historicals vs fitted + forecasted
+   * Useful for plotting historicals vs fitted + forecasted.
    * @param vecs Sequence of vectors of potentially varying lengths, which are extended and
    *             filled with NaNs, as necessary, and then plotted
    */
@@ -61,8 +61,7 @@ object EasyPlot {
     }
     ezplot(extended)
   }
-
-
+  
   /**
    * Autocorrelation function plot
    * @param data array of data to analyze

--- a/src/main/scala/com/cloudera/sparkts/EasyPlot.scala
+++ b/src/main/scala/com/cloudera/sparkts/EasyPlot.scala
@@ -49,6 +49,21 @@ object EasyPlot {
   def ezplot(vecs: Seq[Vector[Double]]): Unit = ezplot(vecs, '-')
 
   /**
+   * Plot multiple series of varying lengths, fills in shorter series with NaNs for plotting.
+   * Useful for plotting historicals vs fitted + forecasted
+   * @param vecs Sequence of vectors of potentially varying lengths, which are extended and
+   *             filled with NaNs, as necessary, and then plotted
+   */
+  def ezplotExtended(vecs: Seq[Vector[Double]]): Unit = {
+    val maxLen = vecs.map(_.length).max
+    val extended = vecs.map { vec =>
+      new DenseVector(vec.toArray ++ Array.fill(maxLen - vec.length)(Double.NaN))
+    }
+    ezplot(extended)
+  }
+
+
+  /**
    * Autocorrelation function plot
    * @param data array of data to analyze
    * @param maxLag maximum lag for autocorrelation


### PR DESCRIPTION
Let's us plot series of varying lengths without throwing a domain mismatch exception. Useful to visualize historicals vs fitted + forecasted.  Useful particularly to visualize ARIMA forecasts and visually verify stationarity of AR process