### PR TITLE
added kpss stationarity test

### DIFF
--- a/src/main/scala/com/cloudera/sparkts/TimeSeriesStatisticalTests.scala
+++ b/src/main/scala/com/cloudera/sparkts/TimeSeriesStatisticalTests.scala
@@ -22,6 +22,8 @@ import com.cloudera.finance.Util
 import org.apache.commons.math3.distribution.{ChiSquaredDistribution, NormalDistribution}
 import org.apache.commons.math3.stat.regression.OLSMultipleLinearRegression
 
+import scala.collection.immutable.ListMap
+
 /**
  * Adapted from statsmodels:
  *    https://github.com/statsmodels/statsmodels/blob/master/statsmodels/tsa/stattools.py
@@ -312,5 +314,105 @@ object TimeSeriesStatisticalTests {
     val bpstat = residuals.length * auxOLS.calculateRSquared()
     val df = factors.cols // auxOLS uses intercept term, so (# of regressors - 1) = # factors cols
     (bpstat, 1 - new ChiSquaredDistribution(df).cumulativeProbability(bpstat))
-  }   
+  }
+
+  /**
+   * Critical values associated with KPSS test when testing with a simple constant
+   * Source:
+   * Kwiatkowski, D., Phillips, P., Schmidt, P., & Shin, Y.
+   * Testing the null hypothesis of stationarity against the alternative of a unit root.
+   * Journal of Econometrics, 159-178.
+   */
+  private val kpssConstantCriticalValues = ListMap(0.10 -> 0.347, 0.05 -> 0.463, 0.025 -> 0.574,
+    0.01 -> 0.739
+  )
+
+  /**
+   * Critical values associated with KPSS test when testing with a constant and time trend
+   * Source:
+   * Kwiatkowski, D., Phillips, P., Schmidt, P., & Shin, Y.
+   * Testing the null hypothesis of stationarity against the alternative of a unit root.
+   * Journal of Econometrics, 159-178.
+   */
+  private val kpssConstantAndTrendCriticalValues = ListMap(0.10 -> 0.119, 0.05 -> 0.146,
+    0.025 -> 0.176, 0.01 -> 0.216
+  )
+
+  /**
+   * Performs the KPSS stationarity test (Kwiatkowski, Phillips, Schmidt and Shin). The null
+   * hypothesis corresponds to stationarity (level stationarity if method = "c", or trend
+   * stationarity if method = "ct"). If method = "c", a regression of the form ts_i = alpha +
+   * error_i is fit. If method = "ct", a regression of the form ts_i = alpha + beta * i + error_i.
+   * The test then performs a check for the variance of the errors. The null hypothesis of
+   * stationarity corresponds to a null hypothesis of variance = 0 for the errors.
+   * For more information please see pg 129 of [[http://faculty.washington
+   * .edu/ezivot/econ584/notes/unitroot.pdf]]. For the original paper on the test, please see
+   * [[http://www.deu.edu.tr/userweb/onder.hanedar/dosyalar/kpss.pdf]].
+   * Finally, the current implementation follows R's tseries package implementation closely, which
+   * can be found at [[https://cran.r-project.org/web/packages/tseries/index.html]]
+   * @param ts time series to test for stationarity
+   * @param method "c" or "ct", short for fitting with a constant or a constant and a time trend
+   * @return the KPSS statistic and a map of critical values according to the method selected
+   */
+  def kpsstest(ts: Vector[Double], method: String): (Double, Map[Double, Double]) = {
+    require(List("c", "ct").contains(method), "trend must be c or ct")
+    val n = ts.length
+    // constant
+    val c = Array.fill(n)(1.0)
+    // create appropriate regression matrix and obtain critical values
+    val (regressors, criticalValues) = if (method == "c") {
+      (c.map(Array(_)), kpssConstantCriticalValues)
+    } else {
+      // time trend
+      val t = Array.tabulate(n)(x => 1.0 + x.toDouble)
+      (Array(c, t).transpose, kpssConstantAndTrendCriticalValues)
+    }
+    val ols = new OLSMultipleLinearRegression()
+    ols.setNoIntercept(true)
+    ols.newSampleData(ts.toArray, regressors)
+    val residuals = ols.estimateResiduals()
+    // sum of (square of cumulative sum of errors)
+    val s2 = residuals.scanLeft(0.0)(_ + _).tail.map(math.pow(_, 2)).sum
+    // long run variance estimate using Newey-West estimator
+    // we follow the default lag used in kpss.test in R's tseries package
+    val lag = (3 * math.sqrt(n) / 13).toInt
+    val longRunVariance = neweyWestVarianceEstimator(residuals, lag)
+    val stat = (s2 / longRunVariance) / (n * n)
+    (stat, criticalValues)
+  }
+
+  /**
+   * Estimates long run variance using the Newey-West estimator, which consists on calculating
+   * the variance between lagged values and applying a weight that decreases as the lag increases.
+   * We translate the C implementation used by R's tseries:kpss.test, found at
+   * https://github.com/cran/tseries/blob/master/src/ppsum.c
+   * However, we add our own comments for clarity.
+   */
+  private def neweyWestVarianceEstimator(errors: Array[Double], lag: Int): Double = {
+    val n = errors.length
+    var sumOfTerms = 0.0
+    var cellContrib = 0.0
+    var i = 0
+    var j = 0
+
+    i = 1
+    while (i <= lag) {
+      j = i
+      cellContrib = 0.0
+      while (j < n) {
+        // covariance between values at time t and time t-i
+        cellContrib += errors(j) * errors(j - i)
+        j += 1
+      }
+      // Newey-West weighing (decreasing weight for longer lags)
+      sumOfTerms += cellContrib * (1 - (i.toDouble / (lag + 1)))
+      i += 1
+    }
+    // we multiply by 2 as we calculated the sum of top row in matrix (lag 0, lag 1), (lag 0, lag 2)
+    // etc but we need to also calculate first column (lag 1, lag 0), (lag 2, lag 0) etc
+    // We divide by n and obtain a partial estimate of the variance, just missing no lag variance
+    val partialEstVar = (sumOfTerms * 2) / n
+    // add no-lag variance
+    partialEstVar + (errors.map(math.pow(_, 2)).sum / n)
+  }
 }

--- a/src/test/scala/com/cloudera/sparkts/TimeSeriesStatisticalTestsSuite.scala
+++ b/src/test/scala/com/cloudera/sparkts/TimeSeriesStatisticalTestsSuite.scala
@@ -102,4 +102,46 @@ class TimeSeriesStatisticalTestsSuite extends FunSuite with ShouldMatchers {
     val (stat2, pval2) = lbtest(vecDep, 2)
     pval2 < 0.05
   }
+
+  test("KPSS test: R equivalence") {
+    // Note that we only test the statistic, as in contrast with the R tseries implementation
+    // we do not calculate a p-value, but rather return a map of appropriate critical values
+    // R's tseries linearly interpolates between critical values.
+
+    // version.string R version 3.2.0 (2015-04-16)
+    // > set.seed(10)
+    // > library(tseries)
+    // > v <- rnorm(20)
+    // > kpss.test(v, "Level")
+    //
+    // KPSS Test for Level Stationarity
+    //
+    // data:  v
+    // KPSS Level = 0.27596, Truncation lag parameter = 1, p-value = 0.1
+    //
+    // Warning message:
+    // In kpss.test(v, "Level") : p-value greater than printed p-value
+    // > kpss.test(v, "Trend")
+    //
+    // KPSS Test for Trend Stationarity
+    //
+    // data:  v
+    // KPSS Trend = 0.05092, Truncation lag parameter = 1, p-value = 0.1
+    //
+    // Warning message:
+    // In kpss.test(v, "Trend") : p-value greater than printed p-value
+
+    val arr = Array(0.0187461709418264, -0.184252542069064, -1.37133054992251, -0.599167715783718,
+      0.294545126567508, 0.389794300700167, -1.20807617542949, -0.363676017470862,
+      -1.62667268170309, -0.256478394123992, 1.10177950308713, 0.755781508027337,
+      -0.238233556018718, 0.98744470341339, 0.741390128383824, 0.0893472664958216,
+      -0.954943856152377, -0.195150384667239, 0.92552126209408, 0.482978524836611
+    )
+    val dv = new DenseVector(arr)
+    val cTest = kpsstest(dv, "c")._1
+    val ctTest = kpsstest(dv, "ct")._1
+
+    cTest should be (0.2759 +- 1e-4)
+    ctTest should be (0.05092 +- 1e-4)
+  }
 }


### PR DESCRIPTION
Added the popular KPSS test for stationarity. Followed R's tseries implementation. Added appropriate tests. 

I mainly added kpss because it is part of the algorithm used by `auto.arima` in Hyndman's `forecast` package in R. I think having something similar to `auto.arima` in the `ARIMA` object would be nice for users, so eventually would like to implement that, and needed kpss for it.