### PR TITLE
Changed the call to index.slice in TimeSeriesRDD and TimeSeries for {differences, quotients, price2ret} 

### DIFF
--- a/src/main/scala/com/cloudera/sparkts/TimeSeries.scala
+++ b/src/main/scala/com/cloudera/sparkts/TimeSeries.scala
@@ -38,7 +38,7 @@ class TimeSeries(val index: DateTimeIndex, val data: DenseMatrix[Double],
    * TimeSeries will be missing the first n date-times.
    */
   def differences(lag: Int): TimeSeries = {
-    mapSeries(index.slice(lag, index.size - 1), vec => diff(vec.toDenseVector, lag))
+    mapSeries(index.slice(lag, index.size), vec => diff(vec.toDenseVector, lag))
   }
 
   /**
@@ -52,7 +52,7 @@ class TimeSeries(val index: DateTimeIndex, val data: DenseMatrix[Double],
    * TimeSeries will be missing the first n date-times.
    */
   def quotients(lag: Int): TimeSeries = {
-    mapSeries(index.slice(lag, index.size - 1), vec => UnivariateTimeSeries.quotients(vec, lag))
+    mapSeries(index.slice(lag, index.size), vec => UnivariateTimeSeries.quotients(vec, lag))
   }
 
   /**
@@ -66,7 +66,7 @@ class TimeSeries(val index: DateTimeIndex, val data: DenseMatrix[Double],
    * compounded) returns.
    */
   def price2ret(): TimeSeries = {
-    mapSeries(index.slice(1, index.size - 1), vec => UnivariateTimeSeries.price2ret(vec, 1))
+    mapSeries(index.slice(1, index.size), vec => UnivariateTimeSeries.price2ret(vec, 1))
   }
 
   def univariateSeriesIterator(): Iterator[Vector[Double]] = {

--- a/src/main/scala/com/cloudera/sparkts/TimeSeriesRDD.scala
+++ b/src/main/scala/com/cloudera/sparkts/TimeSeriesRDD.scala
@@ -64,7 +64,7 @@ class TimeSeriesRDD(val index: DateTimeIndex, parent: RDD[(String, Vector[Double
    * RDD will be missing the first n date-times.
    */
   def differences(n: Int): TimeSeriesRDD = {
-    mapSeries(index.slice(n, index.size - 1), vec => diff(vec.toDenseVector, n))
+    mapSeries(index.slice(n, index.size), vec => diff(vec.toDenseVector, n))
   }
 
   /**
@@ -72,7 +72,7 @@ class TimeSeriesRDD(val index: DateTimeIndex, parent: RDD[(String, Vector[Double
    * RDD will be missing the first n date-times.
    */
   def quotients(n: Int): TimeSeriesRDD = {
-    mapSeries(index.slice(n, index.size - 1), UnivariateTimeSeries.quotients(_, n))
+    mapSeries(index.slice(n, index.size), UnivariateTimeSeries.quotients(_, n))
   }
 
   /**
@@ -80,7 +80,7 @@ class TimeSeriesRDD(val index: DateTimeIndex, parent: RDD[(String, Vector[Double
    * compounded) returns.
    */
   def price2ret(): TimeSeriesRDD = {
-    mapSeries(index.slice(1, index.size - 1), vec => UnivariateTimeSeries.price2ret(vec, 1))
+    mapSeries(index.slice(1, index.size), vec => UnivariateTimeSeries.price2ret(vec, 1))
   }
 
   /**


### PR DESCRIPTION
Currently. if you call any of these functions, the index slice drops the last date as well as the necessary dates at the start (as slice's second parameter is passed in is as index.size - 1), and `mapSeries` makes sure that values align with the index, so we lose a point of data unnecessarily (and diverges from the documentation).
