### PR TITLE
fixing slice when called with 2 ints to include upper bound

### DIFF
--- a/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
+++ b/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
@@ -111,7 +111,7 @@ class UniformDateTimeIndex(val start: Long, val periods: Int, val frequency: Fre
    * {@inheritDoc}
    */
   override def slice(lower: Int, upper: Int): UniformDateTimeIndex = {
-    uniform(frequency.advance(new DateTime(first), lower), upper - lower, frequency)
+    uniform(frequency.advance(new DateTime(first), lower), upper - lower + 1, frequency)
   }
 
   /**


### PR DESCRIPTION
Fixes true underlying issue originally mentioned in #46 by making sure the overloaded `slice` includes upper bound when called with `int` arguments