### PR TITLE
Bugfix in Lag.scala and add TimeSeriesRDD.lags

### DIFF
--- a/src/main/scala/com/cloudera/finance/YahooParser.scala
+++ b/src/main/scala/com/cloudera/finance/YahooParser.scala
@@ -32,7 +32,7 @@ object YahooParser {
       val dt = new DateTime(tokens.head)
       (dt, tokens.tail.map(_.toDouble))
     }.reverse
-    timeSeriesFromSamples(samples, labels)
+    timeSeriesFromIrregularSamples(samples, labels)
   }
 
   def yahooFiles(dir: String, sc: SparkContext): RDD[TimeSeries] = {

--- a/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
+++ b/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
@@ -29,6 +29,8 @@ import com.cloudera.sparkts.DateTimeIndex._
  * To avoid confusion between the meaning of "index" as it appears in "DateTimeIndex" and "index"
  * as a location in an array, in the context of this class, we use "location", or "loc", to refer
  * to the latter.
+ *
+ * NOTE: In the sequence, index 0 represents the oldest point in time. The highest index is the most recent point.
  */
 trait DateTimeIndex extends Serializable {
   /**

--- a/src/main/scala/com/cloudera/sparkts/Lag.scala
+++ b/src/main/scala/com/cloudera/sparkts/Lag.scala
@@ -36,12 +36,13 @@ object Lag {
     val numRows = numObservations - maxLag
     val numCols = maxLag + (if (includeOriginal) 1 else 0)
     val lagMat = Array.ofDim[Double](numRows, numCols)
-    for (r <- 0 until numObservations - maxLag) {
-      for (c <- 0 until maxLag) {
-        lagMat(r)(c) = x(r - c + maxLag - 1)
-      }
-      if (includeOriginal) {
-        lagMat(r)(numCols - 1) = x(r)
+    var initialLag = 1
+
+    if (includeOriginal) initialLag = 0
+
+    for (r <- 0 until numRows) {
+      for (c <- initialLag to maxLag) {
+        lagMat(r)(c - initialLag) = x(r + maxLag - c)
       }
     }
     lagMat
@@ -65,12 +66,14 @@ object Lag {
     val numRows = numObservations - maxLag
     val numCols = maxLag + (if (includeOriginal) 1 else 0)
     val lagMat = new DenseMatrix[Double](numRows, numCols)
+
+    var initialLag = 1
+
+    if (includeOriginal) initialLag = 0
+
     for (r <- 0 until numRows) {
-      for (c <- 0 until maxLag) {
-        lagMat(r, c) = x(r + maxLag - c)
-      }
-      if (includeOriginal) {
-        lagMat(r, numCols - 1) = x(r)
+      for (c <- initialLag to maxLag) {
+        lagMat(r, (c - initialLag)) = x(r + maxLag - c)
       }
     }
     lagMat

--- a/src/main/scala/com/cloudera/sparkts/Lag.scala
+++ b/src/main/scala/com/cloudera/sparkts/Lag.scala
@@ -65,9 +65,9 @@ object Lag {
     val numRows = numObservations - maxLag
     val numCols = maxLag + (if (includeOriginal) 1 else 0)
     val lagMat = new DenseMatrix[Double](numRows, numCols)
-    for (r <- 0 until numObservations - maxLag) {
-      for (c <- 0 until maxLag) {
-        lagMat(r, c) = x(r - c + maxLag - 1)
+    for (r <- 0 until numRows) {
+      for (c <- 0 to maxLag) {
+        lagMat(r, c) = x(r + maxLag - c)
       }
       if (includeOriginal) {
         lagMat(r, numCols - 1) = x(r)

--- a/src/main/scala/com/cloudera/sparkts/Lag.scala
+++ b/src/main/scala/com/cloudera/sparkts/Lag.scala
@@ -78,4 +78,19 @@ object Lag {
     }
     lagMat
   }
+
+  private[sparkts] def lagMatTrimBoth(x: Vector[Double], outputMat: DenseMatrix[Double], maxLag: Int, includeOriginal: Boolean) = {
+    val numObservations = x.size
+    val numRows = numObservations - maxLag
+
+    var initialLag = 1
+
+    if (includeOriginal) initialLag = 0
+
+    for (r <- 0 until numRows) {
+      for (c <- initialLag to maxLag) {
+        outputMat(r, (c - initialLag)) = x(r + maxLag - c)
+      }
+    }
+  }
 }

--- a/src/main/scala/com/cloudera/sparkts/Lag.scala
+++ b/src/main/scala/com/cloudera/sparkts/Lag.scala
@@ -79,7 +79,8 @@ object Lag {
     lagMat
   }
 
-  private[sparkts] def lagMatTrimBoth(x: Vector[Double], outputMat: DenseMatrix[Double], maxLag: Int, includeOriginal: Boolean) = {
+  private[sparkts] def lagMatTrimBoth(x: Vector[Double], outputMat: DenseMatrix[Double],
+                                      maxLag: Int, includeOriginal: Boolean) = {
     val numObservations = x.size
     val numRows = numObservations - maxLag
 

--- a/src/main/scala/com/cloudera/sparkts/Lag.scala
+++ b/src/main/scala/com/cloudera/sparkts/Lag.scala
@@ -66,7 +66,7 @@ object Lag {
     val numCols = maxLag + (if (includeOriginal) 1 else 0)
     val lagMat = new DenseMatrix[Double](numRows, numCols)
     for (r <- 0 until numRows) {
-      for (c <- 0 to maxLag) {
+      for (c <- 0 until maxLag) {
         lagMat(r, c) = x(r + maxLag - c)
       }
       if (includeOriginal) {

--- a/src/main/scala/com/cloudera/sparkts/TimeSeries.scala
+++ b/src/main/scala/com/cloudera/sparkts/TimeSeries.scala
@@ -48,13 +48,6 @@ class TimeSeries(val index: DateTimeIndex, val data: DenseMatrix[Double],
    */
   def lags(maxLag: Int, includeOriginals: Boolean): TimeSeries =
   {
-//    val laggedData = (0 until data.cols).map(colIndex => {
-//      val columnVector: DenseVector[Double] = data(::, colIndex)
-//      val lagsMatrix = UnivariateTimeSeries.lag(columnVector, maxLag, includeOriginals).toDenseMatrix
-//
-//      lagsMatrix
-//    }).reduce((prev: DenseMatrix[Double], next: DenseMatrix[Double]) => DenseMatrix.horzcat(prev, next))
-
     val numCols = maxLag * keys.length + (if (includeOriginals) keys.length else 0)
     val numRows = data.rows - maxLag
 
@@ -69,7 +62,7 @@ class TimeSeries(val index: DateTimeIndex, val data: DenseMatrix[Double],
     val newKeys: Array[String] = keys.indices.map(keyIndex => {
       val key = keys(keyIndex)
 
-      val lagKeys = (1 to maxLag).map(lagOrder => "lag_" + lagOrder.toString() + "(" + key + ")").toArray
+      val lagKeys = (1 to maxLag).map(lagOrder => "lag" + lagOrder.toString() + "(" + key + ")").toArray
 
       if (includeOriginals)
       {

--- a/src/main/scala/com/cloudera/sparkts/TimeSeries.scala
+++ b/src/main/scala/com/cloudera/sparkts/TimeSeries.scala
@@ -27,7 +27,7 @@ class TimeSeries(val index: DateTimeIndex, val data: DenseMatrix[Double],
 
   /**
    * IMPORTANT: currently this assumes that the DateTimeIndex is a UniformDateTimeIndex, not an Irregular one.
-   * This means that this function won't work (yet) on TimeSeries built using timeSeriesFromSamples().
+   * This means that this function won't work (yet) on TimeSeries built using timeSeriesFromIrregularSamples().
    *
    * Lags all individual time series of the TimeSeries instance by up to maxLag amount.
    *

--- a/src/main/scala/com/cloudera/sparkts/TimeSeries.scala
+++ b/src/main/scala/com/cloudera/sparkts/TimeSeries.scala
@@ -46,8 +46,7 @@ class TimeSeries(val index: DateTimeIndex, val data: DenseMatrix[Double],
    *   8 pm   5 	4 	      3         10	9 	      8
    *
    */
-  def lags(maxLag: Int, includeOriginals: Boolean): TimeSeries =
-  {
+  def lags(maxLag: Int, includeOriginals: Boolean): TimeSeries = {
     val numCols = maxLag * keys.length + (if (includeOriginals) keys.length else 0)
     val numRows = data.rows - maxLag
 
@@ -56,13 +55,15 @@ class TimeSeries(val index: DateTimeIndex, val data: DenseMatrix[Double],
       val offset = maxLag + (if (includeOriginals) 1 else 0)
       val start = colIndex * offset
 
-      Lag.lagMatTrimBoth(data(::, colIndex), laggedData(::, start to (start + offset - 1)), maxLag, includeOriginals)
+      Lag.lagMatTrimBoth(data(::, colIndex), laggedData(::, start to (start + offset - 1)), maxLag,
+        includeOriginals)
     })
 
     val newKeys: Array[String] = keys.indices.map(keyIndex => {
       val key = keys(keyIndex)
 
-      val lagKeys = (1 to maxLag).map(lagOrder => "lag" + lagOrder.toString() + "(" + key + ")").toArray
+      val lagKeys = (1 to maxLag).map(lagOrder => "lag" + lagOrder.toString() + "(" + key + ")")
+        .toArray
 
       if (includeOriginals)
       {

--- a/src/main/scala/com/cloudera/sparkts/TimeSeriesRDD.scala
+++ b/src/main/scala/com/cloudera/sparkts/TimeSeriesRDD.scala
@@ -137,9 +137,9 @@ class TimeSeriesRDD(val index: DateTimeIndex, parent: RDD[(String, Vector[Double
     val activeIndices = nans.zipWithIndex.filter(!_._1).map(_._2)
     val newDates = activeIndices.map(index.dateTimeAtLoc)
     val newIndex = DateTimeIndex.irregular(newDates)
-    mapSeries (series => {
+    mapSeries (newIndex, series => {
       new DenseVector[Double](activeIndices.map(x => series(x)))
-    }, newIndex)
+    })
   }
 
   /**

--- a/src/main/scala/com/cloudera/sparkts/UnivariateTimeSeries.scala
+++ b/src/main/scala/com/cloudera/sparkts/UnivariateTimeSeries.scala
@@ -24,6 +24,14 @@ object UnivariateTimeSeries {
 
   /**
    * Lags the univariate time series
+   *
+   * Example input vector: (1.0, 2.0, 3.0, 4.0, 5.0)
+   *
+   * With lag 2 and includeOriginal = true should give output matrix:
+   *
+   * 3  2   1
+   * 4  3   2
+   * 5  4   3
    */
   def lag(ts: Vector[Double], maxLag: Int, includeOriginal: Boolean): Matrix[Double] = {
     Lag.lagMatTrimBoth(ts, maxLag, includeOriginal)

--- a/src/test/scala/com/cloudera/sparkts/TimeSeriesSuite.scala
+++ b/src/test/scala/com/cloudera/sparkts/TimeSeriesSuite.scala
@@ -48,7 +48,7 @@ class TimeSeriesSuite extends FunSuite with ShouldMatchers {
 
     val laggedTimeSeries = originalTimeSeries.lags(2, true)
 
-    laggedTimeSeries.keys should be (Array("a", "lag_1(a)", "lag_2(a)", "b", "lag_1(b)", "lag_2(b)"))
+    laggedTimeSeries.keys should be (Array("a", "lag1(a)", "lag2(a)", "b", "lag1(b)", "lag2(b)"))
     laggedTimeSeries.index.size should be (3)
     laggedTimeSeries.data should be (DenseMatrix((3.0, 2.0, 1.0, 8.0, 7.0, 6.0), (4.0, 3.0, 2.0, 9.0, 8.0, 7.0), (5.0, 4.0, 3.0, 10.0, 9.0, 8.0)))
   }
@@ -62,7 +62,7 @@ class TimeSeriesSuite extends FunSuite with ShouldMatchers {
 
     val laggedTimeSeries = originalTimeSeries.lags(2, false)
 
-    laggedTimeSeries.keys should be (Array("lag_1(a)", "lag_2(a)", "lag_1(b)", "lag_2(b)"))
+    laggedTimeSeries.keys should be (Array("lag1(a)", "lag2(a)", "lag1(b)", "lag2(b)"))
     laggedTimeSeries.index.size should be (3)
     laggedTimeSeries.data should be (DenseMatrix((2.0, 1.0, 7.0, 6.0), (3.0, 2.0, 8.0, 7.0), (4.0, 3.0, 9.0, 8.0)))
   }

--- a/src/test/scala/com/cloudera/sparkts/UnivariateTimeSeriesSuite.scala
+++ b/src/test/scala/com/cloudera/sparkts/UnivariateTimeSeriesSuite.scala
@@ -26,9 +26,14 @@ import org.apache.commons.math3.random.MersenneTwister
 import org.scalatest.{FunSuite, ShouldMatchers}
 
 class UnivariateTimeSeriesSuite extends FunSuite with ShouldMatchers {
-  test("lag") {
+  test("lagIncludeOriginalsTrue") {
     val lagMatrix = UnivariateTimeSeries.lag(Vector(1.0, 2.0, 3.0, 4.0, 5.0), 2, true)
-    lagMatrix should be (new DenseMatrix(3, 3, Array(3.0, 4.0, 5.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0)))
+    lagMatrix should be (DenseMatrix((3.0, 2.0, 1.0), (4.0, 3.0, 2.0), (5.0, 4.0, 3.0)))
+  }
+
+  test("lagIncludeOriginalsFalse") {
+    val lagMatrix = UnivariateTimeSeries.lag(Vector(1.0, 2.0, 3.0, 4.0, 5.0), 2, false)
+    lagMatrix should be (DenseMatrix((2.0, 1.0), (3.0, 2.0), (4.0, 3.0)))
   }
 
   test("lastNotNaN") {

--- a/src/test/scala/com/cloudera/sparkts/UnivariateTimeSeriesSuite.scala
+++ b/src/test/scala/com/cloudera/sparkts/UnivariateTimeSeriesSuite.scala
@@ -26,6 +26,11 @@ import org.apache.commons.math3.random.MersenneTwister
 import org.scalatest.{FunSuite, ShouldMatchers}
 
 class UnivariateTimeSeriesSuite extends FunSuite with ShouldMatchers {
+  test("lag") {
+    val lagMatrix = UnivariateTimeSeries.lag(Vector(1.0, 2.0, 3.0, 4.0, 5.0), 2, true)
+    lagMatrix should be (new DenseMatrix(3, 3, Array(3.0, 4.0, 5.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0)))
+  }
+
   test("lastNotNaN") {
     lastNotNaN(new DenseVector(Array(1.0, 2.0, 3.0, 4.0))) should be (3)
     lastNotNaN(new DenseVector(Array(1.0, 2.0, NaN, 4.0))) should be (3)


### PR DESCRIPTION
There seems to be a bug in the univariate lagging function. When I pass as parameter:

DenseVector(1.0, 2.0, 3.0, 4.0, 5.0), with lag = 2 and includeOriginals = true, the resulting matrix is:

2.0 1.0 1.0

3.0 2.0 2.0

4.0 3.0 3.0

instead I would have expected:

3  2  1
4  3  2
5  4  3

I believe this commit fixes these issues. I create a unit test to verify. Please check if my assumptions about the expected behaviour (and my unit test) are correct.