### PR TITLE
Hybrid date time index

### DIFF
--- a/src/main/java/com/cloudera/sparkts/api/java/DateTimeIndexFactory.java
+++ b/src/main/java/com/cloudera/sparkts/api/java/DateTimeIndexFactory.java
@@ -110,6 +110,20 @@ public final class DateTimeIndexFactory {
     }
 
     /**
+     * Create a HybridDateTimeIndex composed of the given indices using the default date-time zone.
+     */
+    public static HybridDateTimeIndex hybrid(DateTimeIndex[] indices) {
+        return DATE_TIME_INDEX.hybrid(indices);
+    }
+
+    /**
+     * Create a HybridDateTimeIndex composed of the given indices using the provided date-time zone.
+     */
+    public static HybridDateTimeIndex hybrid(DateTimeIndex[] indices, ZoneId zone) {
+        return DATE_TIME_INDEX.hybrid(indices, zone);
+    }
+
+    /**
      * Finds the next business day occurring at or after the given date-time.
      */
     public static ZonedDateTime nextBusinessDay(ZonedDateTime dt, int firstDayOfWeek) {

--- a/src/main/java/com/cloudera/sparkts/api/java/DateTimeIndexFactory.java
+++ b/src/main/java/com/cloudera/sparkts/api/java/DateTimeIndexFactory.java
@@ -11,14 +11,14 @@ public final class DateTimeIndexFactory {
     private DateTimeIndexFactory() {}
 
     /**
-     * Create a UniformDateTimeIndex with the given start time, number of periods, and frequency.
+     * Creates a UniformDateTimeIndex with the given start time, number of periods, and frequency.
      */
     public static UniformDateTimeIndex uniform(long start, int periods, Frequency frequency) {
         return DATE_TIME_INDEX.uniform(start, periods, frequency);
     }
 
     /**
-     * Create a UniformDateTimeIndex with the given start time, number of periods, frequency
+     * Creates a UniformDateTimeIndex with the given start time, number of periods, frequency
      * and time zone.
      */
     public static UniformDateTimeIndex uniform(long start, int periods, Frequency frequency,
@@ -27,14 +27,14 @@ public final class DateTimeIndexFactory {
     }
 
     /**
-     * Create a UniformDateTimeIndex with the given start time, number of periods, and frequency.
+     * Creates a UniformDateTimeIndex with the given start time, number of periods, and frequency.
      */
     public static UniformDateTimeIndex uniform(ZonedDateTime start, int periods, Frequency frequency) {
         return DATE_TIME_INDEX.uniform(start, periods, frequency);
     }
 
     /**
-     * Create a UniformDateTimeIndex with the given start time, number of periods, frequency
+     * Creates a UniformDateTimeIndex with the given start time, number of periods, frequency
      * and time zone.
      */
     public static UniformDateTimeIndex uniform(ZonedDateTime start, int periods, Frequency frequency,
@@ -43,14 +43,14 @@ public final class DateTimeIndexFactory {
     }
 
     /**
-     * Create a UniformDateTimeIndex with the given start time and end time (inclusive) and frequency.
+     * Creates a UniformDateTimeIndex with the given start time and end time (inclusive) and frequency.
      */
     public static UniformDateTimeIndex uniform(long start, long end, Frequency frequency) {
         return DATE_TIME_INDEX.uniform(start, end, frequency);
     }
 
     /**
-     * Create a UniformDateTimeIndex with the given start time and end time (inclusive), frequency
+     * Creates a UniformDateTimeIndex with the given start time and end time (inclusive), frequency
      * and time zone.
      */
     public static UniformDateTimeIndex uniform(long start, long end, Frequency frequency,
@@ -59,7 +59,7 @@ public final class DateTimeIndexFactory {
     }
 
     /**
-     * Create a UniformDateTimeIndex with the given start time and end time (inclusive) and frequency.
+     * Creates a UniformDateTimeIndex with the given start time and end time (inclusive) and frequency.
      */
     public static UniformDateTimeIndex uniform(ZonedDateTime start,
                                                ZonedDateTime end,
@@ -68,7 +68,7 @@ public final class DateTimeIndexFactory {
     }
 
     /**
-     * Create a UniformDateTimeIndex with the given start time and end time (inclusive), frequency
+     * Creates a UniformDateTimeIndex with the given start time and end time (inclusive), frequency
      * and time zone
      */
     public static UniformDateTimeIndex uniform(ZonedDateTime start,
@@ -79,7 +79,7 @@ public final class DateTimeIndexFactory {
     }
 
     /**
-     * Create an IrregularDateTimeIndex composed of the given date-times using the time zone
+     * Creates an IrregularDateTimeIndex composed of the given date-times using the time zone
      * of the first date-time in dts array.
      */
     public static IrregularDateTimeIndex irregular(ZonedDateTime[] dts) {
@@ -87,14 +87,14 @@ public final class DateTimeIndexFactory {
     }
 
     /**
-     * Create an IrregularDateTimeIndex composed of the given date-times and zone
+     * Creates an IrregularDateTimeIndex composed of the given date-times and zone
      */
     public static IrregularDateTimeIndex irregular(ZonedDateTime[] dts, ZoneId zone) {
         return DATE_TIME_INDEX.irregular(dts, zone);
     }
 
     /**
-     * Create an IrregularDateTimeIndex composed of the given date-times, as millis from the epoch
+     * Creates an IrregularDateTimeIndex composed of the given date-times, as millis from the epoch
      * using the default date-time zone.
      */
     public static IrregularDateTimeIndex irregular(long[] dts) {
@@ -102,7 +102,7 @@ public final class DateTimeIndexFactory {
     }
 
     /**
-     * Create an IrregularDateTimeIndex composed of the given date-times, as millis from the epoch
+     * Creates an IrregularDateTimeIndex composed of the given date-times, as millis from the epoch
      * using the provided date-time zone.
      */
     public static IrregularDateTimeIndex irregular(long[] dts, ZoneId zone) {
@@ -110,17 +110,11 @@ public final class DateTimeIndexFactory {
     }
 
     /**
-     * Create a HybridDateTimeIndex composed of the given indices using the default date-time zone.
+     * Creates a HybridDateTimeIndex composed of the given indices.
+     * All indices should have the same zone.
      */
     public static HybridDateTimeIndex hybrid(DateTimeIndex[] indices) {
         return DATE_TIME_INDEX.hybrid(indices);
-    }
-
-    /**
-     * Create a HybridDateTimeIndex composed of the given indices using the provided date-time zone.
-     */
-    public static HybridDateTimeIndex hybrid(DateTimeIndex[] indices, ZoneId zone) {
-        return DATE_TIME_INDEX.hybrid(indices, zone);
     }
 
     /**

--- a/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
+++ b/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
@@ -285,11 +285,7 @@ class HybridDateTimeIndex(
   extends DateTimeIndex {
 
   private val sizeOnLeft: Array[Int] = {
-    var sum: Int = 0
-    (Array(0) ++ indices.init.map(_.size)).map {a =>
-      sum += a
-      sum
-    }
+    indices.init.scanLeft(0)(_ + _.size)
   }
 
   override def slice(interval: Interval): HybridDateTimeIndex = {
@@ -303,9 +299,7 @@ class HybridDateTimeIndex(
     val startIndex = binarySearch(0, indices.length - 1, start)
     val endIndex = binarySearch(0, indices.length - 1, end)
 
-    var newIndices: Array[DateTimeIndex] = Array.empty
-
-    newIndices =
+    val newIndices =
       if (startIndex == endIndex) {
         Array(indices(startIndex).slice(start, end))
       } else {
@@ -315,10 +309,11 @@ class HybridDateTimeIndex(
         val startSlice = Array(startDateTimeIndex.slice(start, startDateTimeIndex.last))
         val endSlice = Array(endDateTimeIndex.slice(endDateTimeIndex.first, end))
 
-        if (endIndex - startIndex == 1)
+        if (endIndex - startIndex == 1) {
           startSlice ++ endSlice
-        else
+        } else {
           startSlice ++ indices.slice(startIndex + 1, endIndex) ++ endSlice
+        }
       }
 
     new HybridDateTimeIndex(newIndices, dateTimeZone)
@@ -342,9 +337,7 @@ class HybridDateTimeIndex(
     val alignedStart = start - sizeOnLeft(startIndex)
     val alignedEnd = end - sizeOnLeft(endIndex)
 
-    var newIndices: Array[DateTimeIndex] = Array.empty
-
-    newIndices =
+    val newIndices =
       if (startIndex == endIndex) {
         Array(indices(startIndex).islice(alignedStart, alignedEnd))
       } else {
@@ -354,10 +347,11 @@ class HybridDateTimeIndex(
         val startSlice = Array(startDateTimeIndex.islice(alignedStart, startDateTimeIndex.size))
         val endSlice = Array(endDateTimeIndex.islice(0, alignedEnd))
 
-        if (endIndex - startIndex == 1)
+        if (endIndex - startIndex == 1) {
           startSlice ++ endSlice
-        else
+        } else {
           startSlice ++ indices.slice(startIndex + 1, endIndex) ++ endSlice
+        }
       }
 
     new HybridDateTimeIndex(newIndices, dateTimeZone)
@@ -433,7 +427,7 @@ class HybridDateTimeIndex(
 
 object DateTimeIndex {
   /**
-   * Create a UniformDateTimeIndex with the given start time, number of periods, frequency,
+   * Creates a UniformDateTimeIndex with the given start time, number of periods, frequency,
    * and time zone(optionally)
    */
   def uniform(
@@ -446,7 +440,7 @@ object DateTimeIndex {
   }
 
   /**
-   * Create a UniformDateTimeIndex with the given start time, number of periods, and frequency
+   * Creates a UniformDateTimeIndex with the given start time, number of periods, and frequency
    * using the time zone of start time.
    */
   def uniform(start: ZonedDateTime, periods: Int, frequency: Frequency): UniformDateTimeIndex = {
@@ -454,7 +448,7 @@ object DateTimeIndex {
   }
 
   /**
-   * Create a UniformDateTimeIndex with the given start time, number of periods, frequency
+   * Creates a UniformDateTimeIndex with the given start time, number of periods, frequency
    * , and time zone
    */
   def uniform(start: ZonedDateTime, periods: Int, frequency: Frequency, zone: ZoneId)
@@ -463,7 +457,7 @@ object DateTimeIndex {
   }
 
   /**
-    * Create a UniformDateTimeIndex with the given start time and end time (inclusive) and frequency.
+    * Creates a UniformDateTimeIndex with the given start time and end time (inclusive) and frequency.
     */
   def uniform(start: ZonedDateTime, end: ZonedDateTime, frequency: Frequency)
     : UniformDateTimeIndex = {
@@ -472,7 +466,7 @@ object DateTimeIndex {
   }
 
   /**
-    * Create a UniformDateTimeIndex with the given start time and end time (inclusive), frequency
+    * Creates a UniformDateTimeIndex with the given start time and end time (inclusive), frequency
     * and time zone.
     */
   def uniform(start: ZonedDateTime, end: ZonedDateTime, frequency: Frequency, tz: ZoneId)
@@ -481,7 +475,7 @@ object DateTimeIndex {
   }
 
   /**
-   * Create a UniformDateTimeIndex with the given start time and end time (inclusive) and frequency.
+   * Creates a UniformDateTimeIndex with the given start time and end time (inclusive) and frequency.
    */
   def uniform(start: Long, end: Long, frequency: Frequency): UniformDateTimeIndex = {
     val tz = ZoneId.systemDefault()
@@ -490,7 +484,7 @@ object DateTimeIndex {
   }
 
   /**
-    * Create a UniformDateTimeIndex with the given start time and end time (inclusive), frequency
+    * Creates a UniformDateTimeIndex with the given start time and end time (inclusive), frequency
     * and time zone.
     */
   def uniform(start: Long, end: Long, frequency: Frequency, tz: ZoneId): UniformDateTimeIndex = {
@@ -499,7 +493,7 @@ object DateTimeIndex {
   }
 
   /**
-   * Create a UniformDateTimeIndex with the given start time and end time (inclusive) and frequency.
+   * Creates a UniformDateTimeIndex with the given start time and end time (inclusive) and frequency.
    */
   def uniformFromInterval(start: Long, end: Long, frequency: Frequency, zone: ZoneId): UniformDateTimeIndex = {
     uniform(start, frequency.difference(longToZonedDateTime(start, zone),
@@ -507,7 +501,7 @@ object DateTimeIndex {
   }
 
   /**
-   * Create a UniformDateTimeIndex with the given start time and end time (inclusive) and frequency
+   * Creates a UniformDateTimeIndex with the given start time and end time (inclusive) and frequency
    * using the time zone of start time.
    */
   def uniformFromInterval(start: ZonedDateTime, end: ZonedDateTime, frequency: Frequency): UniformDateTimeIndex = {
@@ -515,7 +509,7 @@ object DateTimeIndex {
   }
 
   /**
-   * Create a UniformDateTimeIndex with the given start time and end time (inclusive) and frequency
+   * Creates a UniformDateTimeIndex with the given start time and end time (inclusive) and frequency
    * and time zone.
    */
   def uniformFromInterval(start: ZonedDateTime, end: ZonedDateTime, frequency: Frequency, zone: ZoneId)
@@ -524,7 +518,7 @@ object DateTimeIndex {
   }
 
   /**
-   * Create an IrregularDateTimeIndex composed of the given date-times using the time zone
+   * Creates an IrregularDateTimeIndex composed of the given date-times using the time zone
    * of the first date-time in dts array.
    */
   def irregular(dts: Array[ZonedDateTime]): IrregularDateTimeIndex = {
@@ -532,14 +526,14 @@ object DateTimeIndex {
   }
 
   /**
-   * Create an IrregularDateTimeIndex composed of the given date-times and zone
+   * Creates an IrregularDateTimeIndex composed of the given date-times and zone
    */
   def irregular(dts: Array[ZonedDateTime], zone: ZoneId): IrregularDateTimeIndex = {
     new IrregularDateTimeIndex(dts.map(zdt => zonedDateTimeToLong(zdt)), zone)
   }
 
   /**
-   * Create an IrregularDateTimeIndex composed of the given date-times, as millis from the epoch
+   * Creates an IrregularDateTimeIndex composed of the given date-times, as millis from the epoch
    * using the default date-time zone.
    */
   def irregular(dts: Array[Long]): IrregularDateTimeIndex = {
@@ -547,7 +541,7 @@ object DateTimeIndex {
   }
 
   /**
-   * Create an IrregularDateTimeIndex composed of the given date-times, as millis from the epoch
+   * Creates an IrregularDateTimeIndex composed of the given date-times, as millis from the epoch
    * using the provided date-time zone.
    */
   def irregular(dts: Array[Long], zone: ZoneId): IrregularDateTimeIndex = {
@@ -555,16 +549,12 @@ object DateTimeIndex {
   }
 
   /**
-   * Create a HybridDateTimeIndex composed of the given indices using the default date-time zone.
+   * Creates a HybridDateTimeIndex composed of the given indices.
+   * All indices should have the same zone.
    */
   def hybrid(indices: Array[DateTimeIndex]): HybridDateTimeIndex = {
-    new HybridDateTimeIndex(indices)
-  }
-
-  /**
-   * Create a HybridDateTimeIndex composed of the given indices using the provided date-time zone.
-   */
-  def hybrid(indices: Array[DateTimeIndex], zone: ZoneId): HybridDateTimeIndex = {
+    val zone = indices.head.zone
+    require(indices.forall(_.zone.equals(zone)), "All indices should have the same zone")
     new HybridDateTimeIndex(indices, zone)
   }
 
@@ -652,7 +642,7 @@ object DateTimeIndex {
       case "hybrid" =>
         val zone = ZoneId.of(tokens(1))
         val indices = str.split(",", 3).last.split(";").map(fromString)
-        hybrid(indices, zone)
+        new HybridDateTimeIndex(indices, zone)
       case _ => throw new IllegalArgumentException(
         s"DateTimeIndex type ${tokens(0)} not recognized")
     }

--- a/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
+++ b/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
@@ -304,9 +304,24 @@ class HybridDateTimeIndex(
 
   override def dateTimeAtLoc(i: Int): ZonedDateTime = ???
 
-  override def locAtDateTime(dt: ZonedDateTime): Int = ???
+  override def locAtDateTime(dt: ZonedDateTime): Int = {
+    val i = binarySearch(0, indices.length - 1, dt)
+    if (i > -1) indices(i).locAtDateTime(dt)
+    else -1
+  }
 
-  override def locAtDateTime(dt: Long): Int = ???
+  override def locAtDateTime(dt: Long): Int =
+    locAtDateTime(longToZonedDateTime(dt, dateTimeZone))
+
+  private def binarySearch(low: Int, high: Int, dt: ZonedDateTime): Int = {
+    if (low <= high) {
+      val mid = (low + high) >>> 1
+      val midIndex = indices(mid)
+      if (dt.isBefore(midIndex.first)) binarySearch(low, mid - 1, dt)
+      else if (dt.isAfter(midIndex.last)) binarySearch(mid + 1, high, dt)
+      else mid
+    } else -1
+  }
 
   override def toMillisArray(): Array[Long] = {
     indices.map(_.toMillisArray).reduce(_ ++ _)

--- a/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
+++ b/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
@@ -294,13 +294,13 @@ class HybridDateTimeIndex(
 
   override def islice(start: Int, end: Int): DateTimeIndex = ???
 
-  override def first: ZonedDateTime = ???
+  override def first: ZonedDateTime = new ZonedDateTime(indices(0).first, dateTimeZone)
 
-  override def last: ZonedDateTime = ???
+  override def last: ZonedDateTime = new ZonedDateTime(indices(indices.length - 1).last, dateTimeZone)
 
-  override def zone: ZonedDateTime = ???
+  override def zone: ZoneId = dateTimeZone
 
-  override def size: Int = ???
+  override def size: Long = indices.map(_.size.toLong).sum
 
   override def dateTimeAtLoc(i: Int): ZonedDateTime = ???
 
@@ -308,13 +308,23 @@ class HybridDateTimeIndex(
 
   override def locAtDateTime(dt: Long): Int = ???
 
-  override def toMillisArray(): Array[Long] = ???
+  override def toMillisArray(): Array[Long] = {
+    indices.map(_.toMillisArray).reduce(_ ++ _)
+  }
 
-  override def toZonedDateTimeArray(): Array[ZonedDateTime] = ???
+  override def toZonedDateTimeArray(): Array[ZonedDateTime] = {
+    indices.map(_.toZonedDateTimeArray).reduce(_ ++ _)
+  }
 
-  override def equals(other: Any): Boolean = ???
+  override def equals(other: Any): Boolean = {
+    val otherIndex = other.asInstanceOf[HybridDateTimeIndex]
+    otherIndex.indices.sameElements(indices)
+  }
 
-  override def toString: String = ???
+  override def toString: String = {
+    "hybrid," + dateTimeZone.toString + "," +
+      indices.map(_.toString).mkString(";")
+  }
 }
 
 object DateTimeIndex {

--- a/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
+++ b/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
@@ -271,6 +271,52 @@ class IrregularDateTimeIndex(
   }
 }
 
+/**
+ * An implementation of DateTimeIndex that holds a hybrid collection of DateTimeIndex
+ * implementations.
+ *
+ * Indices are assumed to be sorted and disjoint such that
+ * for any two consecutive indices i and j: i.last < j.first
+ *
+ */
+class HybridDateTimeIndex(
+    val indices: Array[DateTimeIndex],
+    val dateTimeZone: ZoneId = ZoneId.systemDefault())
+  extends DateTimeIndex {
+
+  override def slice(interval: Interval): DateTimeIndex = ???
+
+  override def slice(start: ZonedDateTime, end: ZonedDateTime): DateTimeIndex = ???
+
+  override def slice(start: Long, end: Long): DateTimeIndex = ???
+
+  override def islice(range: Range): DateTimeIndex = ???
+
+  override def islice(start: Int, end: Int): DateTimeIndex = ???
+
+  override def first: ZonedDateTime = ???
+
+  override def last: ZonedDateTime = ???
+
+  override def zone: ZonedDateTime = ???
+
+  override def size: Int = ???
+
+  override def dateTimeAtLoc(i: Int): ZonedDateTime = ???
+
+  override def locAtDateTime(dt: ZonedDateTime): Int = ???
+
+  override def locAtDateTime(dt: Long): Int = ???
+
+  override def toMillisArray(): Array[Long] = ???
+
+  override def toZonedDateTimeArray(): Array[ZonedDateTime] = ???
+
+  override def equals(other: Any): Boolean = ???
+
+  override def toString: String = ???
+}
+
 object DateTimeIndex {
   /**
    * Create a UniformDateTimeIndex with the given start time, number of periods, frequency,

--- a/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
+++ b/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
@@ -547,6 +547,20 @@ object DateTimeIndex {
   }
 
   /**
+   * Create a HybridDateTimeIndex composed of the given indices using the default date-time zone.
+   */
+  def hybrid(indices: Array[DateTimeIndex]): HybridDateTimeIndex = {
+    new HybridDateTimeIndex(indices)
+  }
+
+  /**
+   * Create a HybridDateTimeIndex composed of the given indices using the provided date-time zone.
+   */
+  def hybrid(indices: Array[DateTimeIndex], zone: DateTimeZone): HybridDateTimeIndex = {
+    new HybridDateTimeIndex(indices, zone)
+  }
+
+  /**
    * Given the ISO index of the day of week, the method returns the day
    * of week index relative to the first day of week i.e. assuming the
    * the first day of week is the base index and has the value of 1
@@ -627,6 +641,10 @@ object DateTimeIndex {
           dts(i - 2) = ZonedDateTime.parse(tokens(i))
         }
         irregular(dts, zone)
+      case "hybrid" =>
+        val zone = DateTimeZone.forID(tokens(1))
+        val indices = tokens.last.split(";").map(fromString)
+        hybrid(indices, zone)
       case _ => throw new IllegalArgumentException(
         s"DateTimeIndex type ${tokens(0)} not recognized")
     }

--- a/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
+++ b/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
@@ -363,9 +363,10 @@ class HybridDateTimeIndex(
     new HybridDateTimeIndex(newIndices, dateTimeZone)
   }
 
-  override def first: ZonedDateTime = new ZonedDateTime(indices(0).first, dateTimeZone)
+  override def first: ZonedDateTime = indices(0).first.withZoneSameInstant(dateTimeZone)
 
-  override def last: ZonedDateTime = new ZonedDateTime(indices(indices.length - 1).last, dateTimeZone)
+  override def last: ZonedDateTime = indices(indices.length - 1).last
+    .withZoneSameInstant(dateTimeZone)
 
   override def zone: ZoneId = dateTimeZone
 

--- a/src/test/java/com/cloudera/sparkts/api/java/DateTimeIndexFactoryTest.java
+++ b/src/test/java/com/cloudera/sparkts/api/java/DateTimeIndexFactoryTest.java
@@ -19,16 +19,16 @@ public class DateTimeIndexFactoryTest {
     @Test
     public void testToFromString() {
         DateTimeIndex uniformIndex = DateTimeIndexFactory.uniform(
-          ZonedDateTime.of(1990, 4, 10, 0, 0, 0, 0, ZoneId.systemDefault()),
+          ZonedDateTime.of(1990, 4, 10, 0, 0, 0, 0, UTC),
           5,
           new BusinessDayFrequency(2, DayOfWeek.MONDAY.getValue()));
         String uniformStr = uniformIndex.toString();
         assertEquals(fromString(uniformStr), uniformIndex);
 
         DateTimeIndex irregularIndex = DateTimeIndexFactory.irregular(new ZonedDateTime[]{
-          ZonedDateTime.of(1990, 4, 10, 0, 0, 0, 0, ZoneId.systemDefault()),
-          ZonedDateTime.of(1990, 4, 12, 0, 0, 0, 0, ZoneId.systemDefault()),
-          ZonedDateTime.of(1990, 4, 13, 0, 0, 0, 0, ZoneId.systemDefault())
+          ZonedDateTime.of(1990, 4, 10, 0, 0, 0, 0, UTC),
+          ZonedDateTime.of(1990, 4, 12, 0, 0, 0, 0, UTC),
+          ZonedDateTime.of(1990, 4, 13, 0, 0, 0, 0, UTC)
         });
         String irregularStr = irregularIndex.toString();
         assertEquals(fromString(irregularStr), irregularIndex);
@@ -111,7 +111,7 @@ public class DateTimeIndexFactoryTest {
         DateTimeIndex index3 = uniform(zonedDateTime("2015-05-10", UTC), 5,
                 new DayFrequency(2), UTC);
 
-        DateTimeIndex index = hybrid(new DateTimeIndex[]{index1, index2, index3}, UTC);
+        DateTimeIndex index = hybrid(new DateTimeIndex[]{index1, index2, index3});
 
         assertEquals(index.size(), 15);
         assertEquals(index.first(), zonedDateTime("2015-04-10", UTC));

--- a/src/test/java/com/cloudera/sparkts/api/java/DateTimeIndexFactoryTest.java
+++ b/src/test/java/com/cloudera/sparkts/api/java/DateTimeIndexFactoryTest.java
@@ -8,9 +8,14 @@ import java.time.*;
 import org.threeten.extra.Interval;
 import scala.runtime.RichInt;
 import org.junit.Test;
+
+import static com.cloudera.sparkts.api.java.DateTimeIndexFactory.*;
 import static org.junit.Assert.assertEquals;
 
 public class DateTimeIndexFactoryTest {
+    
+    private static ZoneId UTC = ZoneId.of("Z");
+    
     @Test
     public void testToFromString() {
         DateTimeIndex uniformIndex = DateTimeIndexFactory.uniform(
@@ -18,7 +23,7 @@ public class DateTimeIndexFactoryTest {
           5,
           new BusinessDayFrequency(2, DayOfWeek.MONDAY.getValue()));
         String uniformStr = uniformIndex.toString();
-        assertEquals(DateTimeIndexFactory.fromString(uniformStr), uniformIndex);
+        assertEquals(fromString(uniformStr), uniformIndex);
 
         DateTimeIndex irregularIndex = DateTimeIndexFactory.irregular(new ZonedDateTime[]{
           ZonedDateTime.of(1990, 4, 10, 0, 0, 0, 0, ZoneId.systemDefault()),
@@ -26,24 +31,29 @@ public class DateTimeIndexFactoryTest {
           ZonedDateTime.of(1990, 4, 13, 0, 0, 0, 0, ZoneId.systemDefault())
         });
         String irregularStr = irregularIndex.toString();
-        assertEquals(DateTimeIndexFactory.fromString(irregularStr), irregularIndex);
+        assertEquals(fromString(irregularStr), irregularIndex);
+
+        DateTimeIndex hybridIndex = hybrid(new DateTimeIndex[] {
+                uniformIndex, irregularIndex});
+        String hybridStr = hybridIndex.toString();
+        assertEquals(fromString(hybridStr), hybridIndex);
     }
 
     @Test
     public void testUniform() {
         DateTimeIndex index = DateTimeIndexFactory.uniform(
-          ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, ZoneId.of("Z")),
+          ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, UTC),
           5,
           new DayFrequency(2));
         assertEquals(index.size(), 5);
-        assertEquals(index.first(), ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, ZoneId.of("Z")));
-        assertEquals(index.last(), ZonedDateTime.of(2015, 4, 18, 0, 0, 0, 0, ZoneId.of("Z")));
+        assertEquals(index.first(), ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, UTC));
+        assertEquals(index.last(), ZonedDateTime.of(2015, 4, 18, 0, 0, 0, 0, UTC));
 
-        verifySliceUniform(index.slice(ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, ZoneId.of("Z")),
-          ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, ZoneId.of("Z"))));
+        verifySliceUniform(index.slice(ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, UTC),
+          ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, UTC)));
         verifySliceUniform(index.slice(Interval.of(
-          ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, ZoneId.of("Z")).toInstant(),
-          ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, ZoneId.of("Z")).toInstant())));
+          ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, UTC).toInstant(),
+          ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, UTC).toInstant())));
         verifySliceUniform(index.islice(2, 4));
         verifySliceUniform(index.islice(new RichInt(2).until(4)));
         verifySliceUniform(index.islice(new RichInt(2).to(3)));
@@ -51,29 +61,29 @@ public class DateTimeIndexFactoryTest {
 
     private void verifySliceUniform(DateTimeIndex index) {
         assertEquals(index.size(), 2);
-        assertEquals(index.first(), ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, ZoneId.of("Z")));
-        assertEquals(index.last(), ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, ZoneId.of("Z")));
+        assertEquals(index.first(), ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, UTC));
+        assertEquals(index.last(), ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, UTC));
     }
 
     @Test
     public void testIrregular() {
         DateTimeIndex index = DateTimeIndexFactory.irregular(new ZonedDateTime[]{
-                ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, ZoneId.of("Z")),
-                ZonedDateTime.of(2015, 4, 15, 0, 0, 0, 0, ZoneId.of("Z")),
-                ZonedDateTime.of(2015, 4, 17, 0, 0, 0, 0, ZoneId.of("Z")),
-                ZonedDateTime.of(2015, 4, 22, 0, 0, 0, 0, ZoneId.of("Z")),
-                ZonedDateTime.of(2015, 4, 25, 0, 0, 0, 0, ZoneId.of("Z"))
+                ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, UTC),
+                ZonedDateTime.of(2015, 4, 15, 0, 0, 0, 0, UTC),
+                ZonedDateTime.of(2015, 4, 17, 0, 0, 0, 0, UTC),
+                ZonedDateTime.of(2015, 4, 22, 0, 0, 0, 0, UTC),
+                ZonedDateTime.of(2015, 4, 25, 0, 0, 0, 0, UTC)
         });
         assertEquals(index.size(), 5);
-        assertEquals(index.first(), ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, ZoneId.of("Z")));
-        assertEquals(index.last(), ZonedDateTime.of(2015, 4, 25, 0, 0, 0, 0, ZoneId.of("Z")));
+        assertEquals(index.first(), ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, UTC));
+        assertEquals(index.last(), ZonedDateTime.of(2015, 4, 25, 0, 0, 0, 0, UTC));
 
-        verifySliceIrregular(index.slice(ZonedDateTime.of(2015, 4, 15, 0, 0, 0, 0, ZoneId.of("Z")),
-                ZonedDateTime.of(2015, 4, 22, 0, 0, 0, 0, ZoneId.of("Z"))));
+        verifySliceIrregular(index.slice(ZonedDateTime.of(2015, 4, 15, 0, 0, 0, 0, UTC),
+                ZonedDateTime.of(2015, 4, 22, 0, 0, 0, 0, UTC)));
         verifySliceIrregular(index.slice(
                 Interval.of(
-                        ZonedDateTime.of(2015, 4, 15, 0, 0, 0, 0, ZoneId.of("Z")).toInstant(),
-                        ZonedDateTime.of(2015, 4, 22, 0, 0, 0, 0, ZoneId.of("Z")).toInstant())));
+                        ZonedDateTime.of(2015, 4, 15, 0, 0, 0, 0, UTC).toInstant(),
+                        ZonedDateTime.of(2015, 4, 22, 0, 0, 0, 0, UTC).toInstant())));
         verifySliceIrregular(index.islice(1, 4));
         verifySliceIrregular(index.islice(new RichInt(1).until(4)));
         verifySliceIrregular(index.islice(new RichInt(1).to(3)));
@@ -83,7 +93,99 @@ public class DateTimeIndexFactoryTest {
 
     private void verifySliceIrregular(DateTimeIndex index) {
         assertEquals(index.size(), 3);
-        assertEquals(index.first(), ZonedDateTime.of(2015, 4, 15, 0, 0, 0, 0, ZoneId.of("Z")));
-        assertEquals(index.last(), ZonedDateTime.of(2015, 4, 22, 0, 0, 0, 0, ZoneId.of("Z")));
+        assertEquals(index.first(), ZonedDateTime.of(2015, 4, 15, 0, 0, 0, 0, UTC));
+        assertEquals(index.last(), ZonedDateTime.of(2015, 4, 22, 0, 0, 0, 0, UTC));
+    }
+
+    @Test
+    public void testHybrid() {
+        DateTimeIndex index1 = uniform(zonedDateTime("2015-04-10", UTC), 5,
+                new DayFrequency(2), UTC);
+        DateTimeIndex index2 = irregular(new ZonedDateTime[]{
+                zonedDateTime("2015-04-19", UTC),
+                zonedDateTime("2015-04-20", UTC),
+                zonedDateTime("2015-04-21", UTC),
+                zonedDateTime("2015-04-25", UTC),
+                zonedDateTime("2015-04-28", UTC)
+        }, UTC);
+        DateTimeIndex index3 = uniform(zonedDateTime("2015-05-10", UTC), 5,
+                new DayFrequency(2), UTC);
+
+        DateTimeIndex index = hybrid(new DateTimeIndex[]{index1, index2, index3}, UTC);
+
+        assertEquals(index.size(), 15);
+        assertEquals(index.first(), zonedDateTime("2015-04-10", UTC));
+        assertEquals(index.last(), zonedDateTime("2015-05-18", UTC));
+
+        verifySlice1(index.slice(zonedDateTime("2015-04-14", UTC),
+                zonedDateTime("2015-04-16", UTC)));
+        verifySlice1(index.slice(Interval.of(
+                zonedDateTime("2015-04-14", UTC).toInstant(),
+                zonedDateTime("2015-04-16", UTC).toInstant())));
+        verifySlice1(index.islice(2, 4));
+        verifySlice1(index.islice(new RichInt(2).until(4)));
+        verifySlice1(index.islice(new RichInt(2).to(3)));
+
+        verifySlice2(index.slice(zonedDateTime("2015-04-20", UTC),
+                zonedDateTime("2015-04-25", UTC)));
+        verifySlice2(index.slice(Interval.of(
+                zonedDateTime("2015-04-20", UTC).toInstant(),
+                zonedDateTime("2015-04-25", UTC).toInstant())));
+        verifySlice2(index.islice(6, 9));
+        verifySlice2(index.islice(new RichInt(6).until(9)));
+        verifySlice2(index.islice(new RichInt(6).to(8)));
+
+        verifySlice3(index.slice(zonedDateTime("2015-04-16", UTC),
+                zonedDateTime("2015-05-16", UTC)));
+        verifySlice3(index.slice(Interval.of(
+                zonedDateTime("2015-04-16", UTC).toInstant(),
+                zonedDateTime("2015-05-16", UTC).toInstant())));
+        verifySlice3(index.islice(3, 14));
+        verifySlice3(index.islice(new RichInt(3).until(14)));
+        verifySlice3(index.islice(new RichInt(3).to(13)));
+
+        assertEquals(index.dateTimeAtLoc(0), zonedDateTime("2015-04-10", UTC));
+        assertEquals(index.dateTimeAtLoc(4), zonedDateTime("2015-04-18", UTC));
+        assertEquals(index.dateTimeAtLoc(5), zonedDateTime("2015-04-19", UTC));
+        assertEquals(index.dateTimeAtLoc(7), zonedDateTime("2015-04-21", UTC));
+        assertEquals(index.dateTimeAtLoc(9), zonedDateTime("2015-04-28", UTC));
+        assertEquals(index.dateTimeAtLoc(10), zonedDateTime("2015-05-10", UTC));
+        assertEquals(index.dateTimeAtLoc(14), zonedDateTime("2015-05-18", UTC));
+
+        assertEquals(index.locAtDateTime(zonedDateTime("2015-04-10", UTC)), 0);
+        assertEquals(index.locAtDateTime(zonedDateTime("2015-04-18", UTC)), 4);
+        assertEquals(index.locAtDateTime(zonedDateTime("2015-04-19", UTC)), 5);
+        assertEquals(index.locAtDateTime(zonedDateTime("2015-04-21", UTC)), 7);
+        assertEquals(index.locAtDateTime(zonedDateTime("2015-04-28", UTC)), 9);
+        assertEquals(index.locAtDateTime(zonedDateTime("2015-05-10", UTC)), 10);
+        assertEquals(index.locAtDateTime(zonedDateTime("2015-05-18", UTC)), 14);
+    }
+
+    private void verifySlice1(DateTimeIndex index) {
+        assertEquals(index.size(), 2);
+        assertEquals(index.first(), zonedDateTime("2015-04-14", UTC));
+        assertEquals(index.last(), zonedDateTime("2015-04-16", UTC));
+    }
+
+    private void verifySlice2(DateTimeIndex index) {
+        assertEquals(index.size(), 3);
+        assertEquals(index.first(), zonedDateTime("2015-04-20", UTC));
+        assertEquals(index.last(), zonedDateTime("2015-04-25", UTC));
+    }
+
+    private void verifySlice3(DateTimeIndex index) {
+        assertEquals(index.size(), 11);
+        assertEquals(index.first(), zonedDateTime("2015-04-16", UTC));
+        assertEquals(index.last(), zonedDateTime("2015-05-16", UTC));
+    }
+    
+    private static ZonedDateTime zonedDateTime(String dt, ZoneId zone) {
+        String[] tokens = dt.split("-");
+        return ZonedDateTime.of(
+                Integer.parseInt(tokens[0]),
+                Integer.parseInt(tokens[1]),
+                Integer.parseInt(tokens[2]),
+                0, 0, 0, 0, zone
+        );
     }
 }

--- a/src/test/scala/com/cloudera/sparkts/DateTimeIndexSuite.scala
+++ b/src/test/scala/com/cloudera/sparkts/DateTimeIndexSuite.scala
@@ -23,6 +23,8 @@ import org.threeten.extra.Interval
 
 class DateTimeIndexSuite extends FunSuite with ShouldMatchers {
 
+  val UTC = ZoneId.of("Z")
+
   test("LongToDateTimeZone and vice versa") {
     val zdt = ZonedDateTime.of(1990, 4, 10, 0, 0, 0, 0, ZoneId.systemDefault())
 
@@ -41,11 +43,15 @@ class DateTimeIndexSuite extends FunSuite with ShouldMatchers {
     fromString(uniformStr) should be (uniformIndex)
 
     val irregularIndex = irregular(
-      Array(ZonedDateTime.of(1990, 4, 10, 0, 0, 0, 0, ZoneId.of("Z")),
-        ZonedDateTime.of(1990, 4, 12, 0, 0, 0, 0, ZoneId.of("Z")),
-        ZonedDateTime.of(1990, 4, 13, 0, 0, 0, 0, ZoneId.of("Z"))))
+      Array(ZonedDateTime.of(1990, 4, 10, 0, 0, 0, 0, UTC),
+        ZonedDateTime.of(1990, 4, 12, 0, 0, 0, 0, UTC),
+        ZonedDateTime.of(1990, 4, 13, 0, 0, 0, 0, UTC)))
     val irregularStr = irregularIndex.toString
     fromString(irregularStr) should be (irregularIndex)
+
+    val hybridIndex = hybrid(Array(uniformIndex, irregularIndex))
+    val hybridStr = hybridIndex.toString
+    fromString(hybridStr) should be (hybridIndex)
   }
 
   test("to / from string with time zone") {
@@ -60,28 +66,32 @@ class DateTimeIndexSuite extends FunSuite with ShouldMatchers {
         ZonedDateTime.of(1990, 4, 13, 0, 0, 0, 0, zone)))
     val irregularStr = irregularIndex.toString
     fromString(irregularStr) should be (irregularIndex)
+
+    val hybridIndex = hybrid(Array(uniformIndex, irregularIndex), zone)
+    val hybridStr = hybridIndex.toString
+    fromString(hybridStr) should be (hybridIndex)
   }
 
   test("uniform") {
     val index: DateTimeIndex = uniform(
-      ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, ZoneId.of("Z")),
+      ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, UTC),
       5,
       new DayFrequency(2))
     index.size should be (5)
-    index.first should be (ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, ZoneId.of("Z")))
-    index.last should be (ZonedDateTime.of(2015, 4, 18, 0, 0, 0, 0, ZoneId.of("Z")))
+    index.first should be (ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, UTC))
+    index.last should be (ZonedDateTime.of(2015, 4, 18, 0, 0, 0, 0, UTC))
 
     def verifySlice(index: DateTimeIndex) = {
       index.size should be (2)
-      index.first should be (ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, ZoneId.of("Z")))
-      index.last should be (ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, ZoneId.of("Z")))
+      index.first should be (ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, UTC))
+      index.last should be (ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, UTC))
     }
 
-    verifySlice(index.slice(ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, ZoneId.of("Z")),
-      ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, ZoneId.of("Z"))))
+    verifySlice(index.slice(ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, UTC),
+      ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, UTC)))
     verifySlice(index.slice(Interval.of(
-      ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, ZoneId.of("Z")).toInstant(),
-      ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, ZoneId.of("Z")).toInstant())))
+      ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, UTC).toInstant(),
+      ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, UTC).toInstant())))
     verifySlice(index.islice(2, 4))
     verifySlice(index.islice(2 until 4))
     verifySlice(index.islice(2 to 3))
@@ -95,27 +105,109 @@ class DateTimeIndexSuite extends FunSuite with ShouldMatchers {
       "2015-04-17 00:00:00",
       "2015-04-22 00:00:00",
       "2015-04-25 00:00:00"
-    ).map(text => LocalDateTime.parse(text, formatter).atZone(ZoneId.of("Z"))))
+    ).map(text => LocalDateTime.parse(text, formatter).atZone(UTC)))
     index.size should be (5)
-    index.first should be (ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, ZoneId.of("Z")))
-    index.last should be (ZonedDateTime.of(2015, 4, 25, 0, 0, 0, 0, ZoneId.of("Z")))
+    index.first should be (ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, UTC))
+    index.last should be (ZonedDateTime.of(2015, 4, 25, 0, 0, 0, 0, UTC))
 
     def verifySlice(index: DateTimeIndex) = {
       index.size should be (3)
-      index.first should be (ZonedDateTime.of(2015, 4, 15, 0, 0, 0, 0, ZoneId.of("Z")))
-      index.last should be (ZonedDateTime.of(2015, 4, 22, 0, 0, 0, 0, ZoneId.of("Z")))
+      index.first should be (ZonedDateTime.of(2015, 4, 15, 0, 0, 0, 0, UTC))
+      index.last should be (ZonedDateTime.of(2015, 4, 22, 0, 0, 0, 0, UTC))
     }
 
-    verifySlice(index.slice(ZonedDateTime.of(2015, 4, 15, 0, 0, 0, 0, ZoneId.of("Z")),
-      ZonedDateTime.of(2015, 4, 22, 0, 0, 0, 0, ZoneId.of("Z"))))
+    verifySlice(index.slice(ZonedDateTime.of(2015, 4, 15, 0, 0, 0, 0, UTC),
+      ZonedDateTime.of(2015, 4, 22, 0, 0, 0, 0, UTC)))
     verifySlice(index.slice(Interval.of(
-      ZonedDateTime.of(2015, 4, 15, 0, 0, 0, 0, ZoneId.of("Z")).toInstant(),
-      ZonedDateTime.of(2015, 4, 22, 0, 0, 0, 0, ZoneId.of("Z")).toInstant())))
+      ZonedDateTime.of(2015, 4, 15, 0, 0, 0, 0, UTC).toInstant(),
+      ZonedDateTime.of(2015, 4, 22, 0, 0, 0, 0, UTC).toInstant())))
     verifySlice(index.islice(1, 4))
     verifySlice(index.islice(1 until 4))
     verifySlice(index.islice(1 to 3))
 
     // TODO: test bounds that aren't members of the index
+  }
+
+  test("hybrid") {
+    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+    val index1 = uniform(ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, UTC),
+      5, new DayFrequency(2), UTC)
+    val index2 = irregular(Array(
+      "2015-04-19 00:00:00",
+      "2015-04-20 00:00:00",
+      "2015-04-21 00:00:00",
+      "2015-04-25 00:00:00",
+      "2015-04-28 00:00:00"
+    ).map(text => LocalDateTime.parse(text, formatter).atZone(UTC)))
+    val index3 = uniform(ZonedDateTime.of(2015, 5, 10, 0, 0, 0, 0, UTC),
+      5, new DayFrequency(2), UTC)
+
+    val index = hybrid(Array(index1, index2, index3), UTC)
+
+    index.size should be (15)
+    index.first should be (ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, UTC))
+    index.last should be (ZonedDateTime.of(2015, 5, 18, 0, 0, 0, 0, UTC))
+
+    def verifySlice1(index: DateTimeIndex) = {
+      index.size should be (2)
+      index.first should be (ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, UTC))
+      index.last should be (ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, UTC))
+    }
+
+    verifySlice1(index.slice(ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, UTC),
+      ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, UTC)))
+    verifySlice1(index.slice(Interval.of(
+      ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, UTC).toInstant,
+      ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, UTC).toInstant)))
+    verifySlice1(index.islice(2, 4))
+    verifySlice1(index.islice(2 until 4))
+    verifySlice1(index.islice(2 to 3))
+
+    def verifySlice2(index: DateTimeIndex) = {
+      index.size should be (3)
+      index.first should be (ZonedDateTime.of(2015, 4, 20, 0, 0, 0, 0, UTC))
+      index.last should be (ZonedDateTime.of(2015, 4, 25, 0, 0, 0, 0, UTC))
+    }
+
+    verifySlice2(index.slice(ZonedDateTime.of(2015, 4, 20, 0, 0, 0, 0, UTC),
+      ZonedDateTime.of(2015, 4, 25, 0, 0, 0, 0, UTC)))
+    verifySlice2(index.slice(Interval.of(
+      ZonedDateTime.of(2015, 4, 20, 0, 0, 0, 0, UTC).toInstant,
+      ZonedDateTime.of(2015, 4, 25, 0, 0, 0, 0, UTC).toInstant)))
+    verifySlice2(index.islice(6, 9))
+    verifySlice2(index.islice(6 until 9))
+    verifySlice2(index.islice(6 to 8))
+
+    def verifySlice3(index: DateTimeIndex) = {
+      index.size should be (11)
+      index.first should be (ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, UTC))
+      index.last should be (ZonedDateTime.of(2015, 5, 16, 0, 0, 0, 0, UTC))
+    }
+
+    verifySlice3(index.slice(ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, UTC),
+      ZonedDateTime.of(2015, 5, 16, 0, 0, 0, 0, UTC)))
+    verifySlice3(index.slice(Interval.of(
+      ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, UTC).toInstant,
+      ZonedDateTime.of(2015, 5, 16, 0, 0, 0, 0, UTC).toInstant)))
+    verifySlice3(index.islice(3, 14))
+    verifySlice3(index.islice(3 until 14))
+    verifySlice3(index.islice(3 to 13))
+
+    index.dateTimeAtLoc(0) should be (ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, UTC))
+    index.dateTimeAtLoc(4) should be (ZonedDateTime.of(2015, 4, 18, 0, 0, 0, 0, UTC))
+    index.dateTimeAtLoc(5) should be (ZonedDateTime.of(2015, 4, 19, 0, 0, 0, 0, UTC))
+    index.dateTimeAtLoc(7) should be (ZonedDateTime.of(2015, 4, 21, 0, 0, 0, 0, UTC))
+    index.dateTimeAtLoc(9) should be (ZonedDateTime.of(2015, 4, 28, 0, 0, 0, 0, UTC))
+    index.dateTimeAtLoc(10) should be (ZonedDateTime.of(2015, 5, 10, 0, 0, 0, 0, UTC))
+    index.dateTimeAtLoc(14) should be (ZonedDateTime.of(2015, 5, 18, 0, 0, 0, 0, UTC))
+
+    index.locAtDateTime(ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, UTC)) should be (0)
+    index.locAtDateTime(ZonedDateTime.of(2015, 4, 18, 0, 0, 0, 0, UTC)) should be (4)
+    index.locAtDateTime(ZonedDateTime.of(2015, 4, 19, 0, 0, 0, 0, UTC)) should be (5)
+    index.locAtDateTime(ZonedDateTime.of(2015, 4, 21, 0, 0, 0, 0, UTC)) should be (7)
+    index.locAtDateTime(ZonedDateTime.of(2015, 4, 28, 0, 0, 0, 0, UTC)) should be (9)
+    index.locAtDateTime(ZonedDateTime.of(2015, 5, 10, 0, 0, 0, 0, UTC)) should be (10)
+    index.locAtDateTime(ZonedDateTime.of(2015, 5, 18, 0, 0, 0, 0, UTC)) should be (14)
   }
 
   test("rebased day of week") {
@@ -140,27 +232,42 @@ class DateTimeIndexSuite extends FunSuite with ShouldMatchers {
 
   test("locAtDatetime returns -1") {
     val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
-    val index = irregular(Array(
+    val index1 = irregular(Array(
       "2015-04-14 00:00:00",
       "2015-04-15 00:00:00",
       "2015-04-17 00:00:00",
       "2015-04-22 00:00:00",
       "2015-04-25 00:00:00"
-    ).map(text => LocalDateTime.parse(text, formatter).atZone(ZoneId.of("Z"))))
-    index.size should be (5)
-    index.first should be (ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, ZoneId.of("Z")))
-    index.last should be (ZonedDateTime.of(2015, 4, 25, 0, 0, 0, 0, ZoneId.of("Z")))
+    ).map(text => LocalDateTime.parse(text, formatter).atZone(UTC)))
+    val index2 = uniform(ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, UTC),
+      5, new DayFrequency(2))
+    val index = hybrid(Array(index1, index2), UTC)
 
-    val loc1 = index.locAtDateTime(ZonedDateTime.of(2015, 4, 15, 0, 0, 0, 0, ZoneId.of("Z")))
+    index.first should be (ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, UTC))
+    index.last should be (ZonedDateTime.of(2015, 5, 18, 0, 0, 0, 0, UTC))
+
+    val loc1 = index.locAtDateTime(ZonedDateTime.of(2015, 4, 15, 0, 0, 0, 0, UTC))
     loc1 should be (1)
 
-    val loc2 = index.locAtDateTime(ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, ZoneId.of("Z")))
+    val loc2 = index.locAtDateTime(ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, UTC))
     loc2 should be (-1)
 
-    val loc3 = index.locAtDateTime(ZonedDateTime.of(2015, 4, 25, 0, 0, 0, 0, ZoneId.of("Z")))
+    val loc3 = index.locAtDateTime(ZonedDateTime.of(2015, 4, 25, 0, 0, 0, 0, UTC))
     loc3 should be (4)
 
-    val loc4 = index.locAtDateTime(ZonedDateTime.of(2015, 4, 24, 0, 0, 0, 0, ZoneId.of("Z")))
+    val loc4 = index.locAtDateTime(ZonedDateTime.of(2015, 4, 24, 0, 0, 0, 0, UTC))
     loc4 should be (-1)
+
+    val loc5 = index.locAtDateTime(ZonedDateTime.of(2015, 5, 12, 0, 0, 0, 0, UTC))
+    loc5 should be (6)
+
+    val loc6 = index.locAtDateTime(ZonedDateTime.of(2015, 5, 13, 0, 0, 0, 0, UTC))
+    loc6 should be (-1)
+
+    val loc7 = index.locAtDateTime(ZonedDateTime.of(2015, 5, 18, 0, 0, 0, 0, UTC))
+    loc7 should be (9)
+
+    val loc8 = index.locAtDateTime(ZonedDateTime.of(2015, 5, 19, 0, 0, 0, 0, UTC))
+    loc8 should be (-1)
   }
 }

--- a/src/test/scala/com/cloudera/sparkts/DateTimeIndexSuite.scala
+++ b/src/test/scala/com/cloudera/sparkts/DateTimeIndexSuite.scala
@@ -36,7 +36,7 @@ class DateTimeIndexSuite extends FunSuite with ShouldMatchers {
 
   test("to / from string") {
     val uniformIndex = uniform(
-      ZonedDateTime.of(1990, 4, 10, 0, 0, 0, 0, ZoneId.systemDefault()),
+      ZonedDateTime.of(1990, 4, 10, 0, 0, 0, 0, UTC),
       5,
       new BusinessDayFrequency(2))
     val uniformStr = uniformIndex.toString
@@ -67,7 +67,7 @@ class DateTimeIndexSuite extends FunSuite with ShouldMatchers {
     val irregularStr = irregularIndex.toString
     fromString(irregularStr) should be (irregularIndex)
 
-    val hybridIndex = hybrid(Array(uniformIndex, irregularIndex), zone)
+    val hybridIndex = hybrid(Array(uniformIndex, irregularIndex))
     val hybridStr = hybridIndex.toString
     fromString(hybridStr) should be (hybridIndex)
   }
@@ -142,7 +142,7 @@ class DateTimeIndexSuite extends FunSuite with ShouldMatchers {
     val index3 = uniform(ZonedDateTime.of(2015, 5, 10, 0, 0, 0, 0, UTC),
       5, new DayFrequency(2), UTC)
 
-    val index = hybrid(Array(index1, index2, index3), UTC)
+    val index = hybrid(Array(index1, index2, index3))
 
     index.size should be (15)
     index.first should be (ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, UTC))
@@ -241,7 +241,7 @@ class DateTimeIndexSuite extends FunSuite with ShouldMatchers {
     ).map(text => LocalDateTime.parse(text, formatter).atZone(UTC)))
     val index2 = uniform(ZonedDateTime.of(2015, 5, 10, 0, 0, 0, 0, UTC),
       5, new DayFrequency(2))
-    val index = hybrid(Array(index1, index2), UTC)
+    val index = hybrid(Array(index1, index2))
 
     index.first should be (ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, UTC))
     index.last should be (ZonedDateTime.of(2015, 5, 18, 0, 0, 0, 0, UTC))

--- a/src/test/scala/com/cloudera/sparkts/DateTimeIndexSuite.scala
+++ b/src/test/scala/com/cloudera/sparkts/DateTimeIndexSuite.scala
@@ -239,7 +239,7 @@ class DateTimeIndexSuite extends FunSuite with ShouldMatchers {
       "2015-04-22 00:00:00",
       "2015-04-25 00:00:00"
     ).map(text => LocalDateTime.parse(text, formatter).atZone(UTC)))
-    val index2 = uniform(ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, UTC),
+    val index2 = uniform(ZonedDateTime.of(2015, 5, 10, 0, 0, 0, 0, UTC),
       5, new DayFrequency(2))
     val index = hybrid(Array(index1, index2), UTC)
 


### PR DESCRIPTION
Additions to the public API:
- ```HybridDateTimeIndex``` is an implementation of ```DateTimeIndex``` that holds a hybrid collection of different types of ```DateTimeIndex```. Indices are assumed to be sorted and disjoint such that for any two consecutive indices ```i``` and ```j```: ```i.last < j.first```. This is helpful for transformations on multiple indices. Factory methods for constructing ```HybridDateTimeIndex```:
 - ```DateTimeIndex.hybrid(indices: Array[DateTimeIndex])```
 - ```DateTimeIndex.hybrid(indices: Array[DateTimeIndex], zone: DateTimeZone)```
 - ```DateTimeIndex.fromString```