### PR TITLE
TimeSeriesRDD/toInstants*: avoid dtLoc overflow and colexpr error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.version>1.7</java.version>
+    <java.version>1.8</java.version>
     <scala.minor.version>2.10</scala.minor.version>
     <scala.complete.version>${scala.minor.version}.4</scala.complete.version>
     <spark.version>1.3.1</spark.version>

--- a/src/main/scala/com/cloudera/sparkts/TimeSeriesRDD.scala
+++ b/src/main/scala/com/cloudera/sparkts/TimeSeriesRDD.scala
@@ -278,7 +278,7 @@ class TimeSeriesRDD[K](val index: DateTimeIndex, parent: RDD[(K, Vector)])
     val partitioner = new Partitioner() {
       val nPart = if (nPartitions == -1) parent.partitions.length else nPartitions
       override def numPartitions: Int = nPart
-      override def getPartition(key: Any): Int = key.asInstanceOf[(Int, _)]._1 / nPart
+      override def getPartition(key: Any): Int = key.asInstanceOf[(Int, _)]._1 % nPart
     }
     implicit val ordering = new Ordering[(Int, Int)] {
       override def compare(a: (Int, Int), b: (Int, Int)): Int = {
@@ -364,7 +364,7 @@ class TimeSeriesRDD[K](val index: DateTimeIndex, parent: RDD[(K, Vector)])
       (timestamp, v.toArray)
     }.toDF()
 
-    val dataColExpr = keys.zipWithIndex.map { case (key, i) => s"_2[$i] AS $key" }
+    val dataColExpr = keys.zipWithIndex.map { case (key, i) => s"_2[$i] AS `$key`" }
     val allColsExpr = "_1 AS instant" +: dataColExpr
 
     result.selectExpr(allColsExpr: _*)


### PR DESCRIPTION
### See the following tests.
*****
#### line 281 related
```scala
object run extends App {
  val conf = new SparkConf().setMaster("local").setAppName(getClass.getName)
  TimeSeriesKryoRegistrator.registerKryoClasses(conf)
  val sc = new SparkContext(conf)
  val seriesVecs = (0 until 200 by 40).map(
    x => new DenseVector((x until x + 40).map(_.toDouble).toArray))
  val labels = Array("a", "b", "c", "d", "e")
  val start = ZonedDateTime.of(2015, 4, 9, 0, 0, 0, 0, ZoneId.systemDefault())
  val index = uniform(start, 40, new DayFrequency(1))
  val rdd = sc.parallelize(labels.zip(seriesVecs.map(_.asInstanceOf[Vector])), 3)
  val tsRdd = new TimeSeriesRDD[String](index, rdd)
  tsRdd.toInstants().collect.foreach(println)
}
```
When the col is very large, the original `getPartition` will overflow
*****
#### line 367 related
```scala
object run extends App {
    val conf = new SparkConf().setMaster("local").setAppName(getClass.getName)
    TimeSeriesKryoRegistrator.registerKryoClasses(conf)
    val sc = new SparkContext(conf)
    val sqlContext = new SQLContext(sc)

    val seriesVecs = (0 until 20 by 4).map(
      x => new DenseVector((x until x + 4).map(_.toDouble).toArray))
    val labels = Array("a.1", "b.1", "c.1", "d", "e")
    val start = ZonedDateTime.of(2015, 4, 9, 0, 0, 0, 0, ZoneId.of("Z"))
    val index = uniform(start, 4, new DayFrequency(1))

    val rdd = sc.parallelize(labels.zip(seriesVecs.map(_.asInstanceOf[Vector])), 3)
    val tsRdd = new TimeSeriesRDD[String](index, rdd)

    val samplesDF = tsRdd.toInstantsDataFrame(sqlContext)
    samplesDF.printSchema()
}
```
If colname contains '.', the toInstantsDataFrame will now work, while building from csvs, a '.' is always included in a colname. 

:christmas_tree: 