### PR TITLE
Generic date-time index rebaser

### DIFF
--- a/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
+++ b/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
@@ -224,7 +224,7 @@ class UniformDateTimeIndex(
     new Iterator[ZonedDateTime] {
       var current = first
 
-      override def hasNext: Boolean = current.isBefore(last)
+      override def hasNext: Boolean = current.compareTo(last) <= 0
 
       override def next(): ZonedDateTime = {
         val ret = current
@@ -321,7 +321,7 @@ class IrregularDateTimeIndex(
 
       override def hasNext: Boolean = instIter.hasNext
 
-      override def next(): ZonedDateTime = longToZonedDateTime(instIter.next)
+      override def next(): ZonedDateTime = longToZonedDateTime(instIter.next, dateTimeZone)
     }
   }
 }
@@ -499,7 +499,7 @@ class HybridDateTimeIndex(
         }
       }
 
-      override def next(): Long = if (hasNext) milIter.next else null
+      override def next(): Long = if (hasNext) milIter.next else -1
     }
   }
 

--- a/src/main/scala/com/cloudera/sparkts/TimeSeriesUtils.scala
+++ b/src/main/scala/com/cloudera/sparkts/TimeSeriesUtils.scala
@@ -195,7 +195,7 @@ private[sparkts] object TimeSeriesUtils {
     }
   }
 
-  private def rebaserGeneric(
+  def rebaserGeneric(
       sourceIndex: DateTimeIndex,
       targetIndex: DateTimeIndex,
       defaultValue: Double): Vector[Double] => Vector[Double] = {

--- a/src/test/scala/com/cloudera/sparkts/DateTimeIndexSuite.scala
+++ b/src/test/scala/com/cloudera/sparkts/DateTimeIndexSuite.scala
@@ -95,6 +95,9 @@ class DateTimeIndexSuite extends FunSuite with ShouldMatchers {
     verifySlice(index.islice(2, 4))
     verifySlice(index.islice(2 until 4))
     verifySlice(index.islice(2 to 3))
+
+    index.millisIterator.toArray should be (index.toMillisArray)
+    index.zonedDateTimeIterator.toArray should be (index.toZonedDateTimeArray)
   }
 
   test("irregular") {
@@ -105,7 +108,7 @@ class DateTimeIndexSuite extends FunSuite with ShouldMatchers {
       "2015-04-17 00:00:00",
       "2015-04-22 00:00:00",
       "2015-04-25 00:00:00"
-    ).map(text => LocalDateTime.parse(text, formatter).atZone(UTC)))
+    ).map(text => LocalDateTime.parse(text, formatter).atZone(UTC)), UTC)
     index.size should be (5)
     index.first should be (ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, UTC))
     index.last should be (ZonedDateTime.of(2015, 4, 25, 0, 0, 0, 0, UTC))
@@ -125,6 +128,8 @@ class DateTimeIndexSuite extends FunSuite with ShouldMatchers {
     verifySlice(index.islice(1 until 4))
     verifySlice(index.islice(1 to 3))
 
+    index.millisIterator.toArray should be (index.toMillisArray)
+    index.zonedDateTimeIterator.toArray should be (index.toZonedDateTimeArray)
     // TODO: test bounds that aren't members of the index
   }
 
@@ -138,7 +143,7 @@ class DateTimeIndexSuite extends FunSuite with ShouldMatchers {
       "2015-04-21 00:00:00",
       "2015-04-25 00:00:00",
       "2015-04-28 00:00:00"
-    ).map(text => LocalDateTime.parse(text, formatter).atZone(UTC)))
+    ).map(text => LocalDateTime.parse(text, formatter).atZone(UTC)), UTC)
     val index3 = uniform(ZonedDateTime.of(2015, 5, 10, 0, 0, 0, 0, UTC),
       5, new DayFrequency(2), UTC)
 
@@ -208,6 +213,9 @@ class DateTimeIndexSuite extends FunSuite with ShouldMatchers {
     index.locAtDateTime(ZonedDateTime.of(2015, 4, 28, 0, 0, 0, 0, UTC)) should be (9)
     index.locAtDateTime(ZonedDateTime.of(2015, 5, 10, 0, 0, 0, 0, UTC)) should be (10)
     index.locAtDateTime(ZonedDateTime.of(2015, 5, 18, 0, 0, 0, 0, UTC)) should be (14)
+
+    index.millisIterator.toArray should be (index.toMillisArray)
+    index.zonedDateTimeIterator.toArray should be (index.toZonedDateTimeArray)
   }
 
   test("rebased day of week") {

--- a/src/test/scala/com/cloudera/sparkts/RebaseSuite.scala
+++ b/src/test/scala/com/cloudera/sparkts/RebaseSuite.scala
@@ -25,8 +25,11 @@ import java.time._
 import org.scalatest.{FunSuite, ShouldMatchers}
 
 class RebaseSuite extends FunSuite with ShouldMatchers {
+  private type Rebaser = Vector[Double] => Vector[Double]
+  private val Z = ZoneId.of("Z")
+
   test("iterateWithUniformFrequency single value") {
-    val baseDT = ZonedDateTime.of(2015, 4, 8, 0, 0, 0, 0, ZoneId.of("Z"))
+    val baseDT = ZonedDateTime.of(2015, 4, 8, 0, 0, 0, 0, Z)
     val dts = Array(baseDT)
     val values = Array(1.0)
     val iter = iterateWithUniformFrequency(dts.zip(values).iterator, new DayFrequency(1), 47.0)
@@ -34,7 +37,7 @@ class RebaseSuite extends FunSuite with ShouldMatchers {
   }
 
   test("iterateWithUniformFrequency no gaps") {
-    val baseDT = ZonedDateTime.of(2015, 4, 8, 0, 0, 0, 0, ZoneId.of("Z"))
+    val baseDT = ZonedDateTime.of(2015, 4, 8, 0, 0, 0, 0, Z)
     val dts = Array(baseDT, baseDT.plusDays(1), baseDT.plusDays(2), baseDT.plusDays(3))
     val values = Array(1.0, 2.0, 3.0, 4.0)
     val iter = iterateWithUniformFrequency(dts.zip(values).iterator, new DayFrequency(1))
@@ -43,7 +46,7 @@ class RebaseSuite extends FunSuite with ShouldMatchers {
   }
 
   test("iterateWithUniformFrequency multiple gaps") {
-    val baseDT = ZonedDateTime.of(2015, 4, 8, 0, 0, 0, 0, ZoneId.of("Z"))
+    val baseDT = ZonedDateTime.of(2015, 4, 8, 0, 0, 0, 0, Z)
     val dts = Array(baseDT, baseDT.plusDays(2), baseDT.plusDays(5))
     val values = Array(1.0, 2.0, 3.0)
     val iter = iterateWithUniformFrequency(dts.zip(values).iterator, new DayFrequency(1), 47.0)
@@ -53,115 +56,135 @@ class RebaseSuite extends FunSuite with ShouldMatchers {
 
   test("uniform source same range") {
     val vec = new DenseVector((0 until 10).map(_.toDouble).toArray)
-    val source = uniform(ZonedDateTime.of(2015, 4, 8, 0, 0, 0, 0, ZoneId.of("Z")),
+    val source = uniform(ZonedDateTime.of(2015, 4, 8, 0, 0, 0, 0, Z),
       vec.length,
       1.businessDays)
     val target = source
-    val rebased = rebase(source, target, vec, NaN)
-    rebased.length should be (vec.length)
-    rebased should be (vec)
+
+    assertRebaser(rebaser(source, target, NaN), vec, vec.toArray)
+    assertRebaser(rebaserGeneric(source, target, NaN), vec, vec.toArray)
   }
 
   test("uniform source, target fits in source") {
     val vec = new DenseVector((0 until 10).map(_.toDouble).toArray)
-    val source = uniform(ZonedDateTime.of(2015, 4, 8, 0, 0, 0, 0, ZoneId.of("Z")),
+    val source = uniform(ZonedDateTime.of(2015, 4, 8, 0, 0, 0, 0, Z),
       vec.length,
       1.businessDays)
-    val target = uniform(ZonedDateTime.of(2015, 4, 9, 0, 0, 0, 0, ZoneId.of("Z")),
+    val target = uniform(ZonedDateTime.of(2015, 4, 9, 0, 0, 0, 0, Z),
       5,
       1.businessDays)
-    val rebased = rebase(source, target, vec, NaN)
-    rebased should be (new DenseVector(Array(1.0, 2.0, 3.0, 4.0, 5.0)))
+
+    assertRebaser(rebaser(source, target, NaN), vec, Array(1.0, 2.0, 3.0, 4.0, 5.0))
+    assertRebaser(rebaserGeneric(source, target, NaN), vec, Array(1.0, 2.0, 3.0, 4.0, 5.0))
   }
 
   test("uniform source, target overlaps source ") {
     val vec = new DenseVector((0 until 10).map(_.toDouble).toArray)
-    val source = uniform(ZonedDateTime.of(2015, 4, 8, 0, 0, 0, 0, ZoneId.of("Z")),
+    val source = uniform(ZonedDateTime.of(2015, 4, 8, 0, 0, 0, 0, Z),
       vec.length,
       new DayFrequency(1))
-    val targetBefore = uniform(ZonedDateTime.of(2015, 4, 4, 0, 0, 0, 0, ZoneId.of("Z")),
+    val targetBefore = uniform(ZonedDateTime.of(2015, 4, 4, 0, 0, 0, 0, Z),
       8,
       new DayFrequency(1))
-    val targetAfter = uniform(ZonedDateTime.of(2015, 4, 11, 0, 0, 0, 0, ZoneId.of("Z")),
+    val targetAfter = uniform(ZonedDateTime.of(2015, 4, 11, 0, 0, 0, 0, Z),
       8,
       new DayFrequency(1))
-    val rebasedBefore = rebase(source, targetBefore, vec, NaN)
-    val rebasedAfter = rebase(source, targetAfter, vec, NaN)
-    assertArraysEqualWithNaN(
-      rebasedBefore.valuesIterator.toArray,
+
+    assertRebaser(rebaser(source, targetBefore, NaN), vec,
       Array(NaN, NaN, NaN, NaN, 0.0, 1.0, 2.0, 3.0))
-    assertArraysEqualWithNaN(
-      rebasedAfter.valuesIterator.toArray,
+    assertRebaser(rebaser(source, targetAfter, NaN), vec,
+      Array(3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, NaN))
+
+    assertRebaser(rebaserGeneric(source, targetBefore, NaN), vec,
+      Array(NaN, NaN, NaN, NaN, 0.0, 1.0, 2.0, 3.0))
+    assertRebaser(rebaserGeneric(source, targetAfter, NaN), vec,
       Array(3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, NaN))
   }
 
   test("uniform source, source fits in target") {
     val vec = new DenseVector((0 until 4).map(_.toDouble).toArray)
-    val source = uniform(ZonedDateTime.of(2015, 4, 8, 0, 0, 0, 0, ZoneId.of("Z")),
+    val source = uniform(ZonedDateTime.of(2015, 4, 8, 0, 0, 0, 0, Z),
       vec.length,
       1.businessDays)
-    val target = uniform(ZonedDateTime.of(2015, 4, 7, 0, 0, 0, 0, ZoneId.of("Z")),
+    val target = uniform(ZonedDateTime.of(2015, 4, 7, 0, 0, 0, 0, Z),
       8,
       1.businessDays)
-    val rebased = rebase(source, target, vec, NaN)
-    assertArraysEqualWithNaN(
-      rebased.valuesIterator.toArray,
+
+    assertRebaser(rebaser(source, target, NaN), vec,
+      Array(NaN, 0.0, 1.0, 2.0, 3.0, NaN, NaN, NaN))
+    assertRebaser(rebaserGeneric(source, target, NaN), vec,
       Array(NaN, 0.0, 1.0, 2.0, 3.0, NaN, NaN, NaN))
   }
 
-  test("irregular source same range") {
+  test("irregular & uniform, same range") {
     val vec = new DenseVector((4 until 10).map(_.toDouble).toArray)
     val source = irregular((4 until 10).map(d =>
-      ZonedDateTime.of(2015, 4, d, 0, 0, 0, 0, ZoneId.of("Z"))).toArray)
+      ZonedDateTime.of(2015, 4, d, 0, 0, 0, 0, Z)).toArray)
     vec.size should be (source.size)
-    val target = uniform(ZonedDateTime.of(2015, 4, 4, 0, 0, 0, 0, ZoneId.of("Z")),
+    val target = uniform(ZonedDateTime.of(2015, 4, 4, 0, 0, 0, 0, Z),
       vec.length,
       new DayFrequency(1))
-    val rebased = rebase(source, target, vec, NaN)
-    rebased should be (vec)
+
+    assertRebaser(rebaser(source, target, NaN), vec, vec.toArray)
+    assertRebaser(rebaserGeneric(source, target, NaN), vec, vec.toArray)
+
+    assertRebaser(rebaser(target, source, NaN), vec, vec.toArray)
+    assertRebaser(rebaserGeneric(target, source, NaN), vec, vec.toArray)
   }
 
   test("irregular source, hole gets filled default value") {
-    val dt = ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, ZoneId.of("Z"))
+    val dt = ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, Z)
     val source = irregular(Array(dt, dt.plusDays(1), dt.plusDays(3)))
     val target = uniform(dt, 4, new DayFrequency(1))
     val vec = new DenseVector(Array(1.0, 2.0, 3.0))
-    val rebased = rebase(source, target, vec, 47.0)
-    rebased.toArray should be (Array(1.0, 2.0, 47.0, 3.0))
+
+    assertRebaser(rebaser(source, target, 47.0), vec, Array(1.0, 2.0, 47.0, 3.0))
+    assertRebaser(rebaserGeneric(source, target, 47.0), vec, Array(1.0, 2.0, 47.0, 3.0))
   }
 
   test("irregular source, target fits in source") {
-    val dt = ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, ZoneId.of("Z"))
+    val dt = ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, Z)
     val source = irregular(Array(dt, dt.plusDays(1), dt.plusDays(3)))
     val target = uniform(dt.plusDays(1), 2, new DayFrequency(1))
     val vec = new DenseVector(Array(1.0, 2.0, 3.0))
-    val rebased = rebase(source, target, vec, 47.0)
-    rebased.toArray should be (Array(2.0, 47.0))
+
+    assertRebaser(rebaser(source, target, 47.0), vec, Array(2.0, 47.0))
+    assertRebaser(rebaserGeneric(source, target, 47.0), vec, Array(2.0, 47.0))
   }
 
   test("irregular source, target overlaps source ") {
-    val dt = ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, ZoneId.of("Z"))
+    val dt = ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, Z)
     val source = irregular(Array(dt, dt.plusDays(1), dt.plusDays(3)))
-    val targetBefore = uniform(ZonedDateTime.of(2015, 4, 8, 0, 0, 0, 0, ZoneId.of("Z")),
+    val targetBefore = uniform(ZonedDateTime.of(2015, 4, 8, 0, 0, 0, 0, Z),
       4,
       new DayFrequency(1))
     val vec = new DenseVector(Array(1.0, 2.0, 3.0))
-    val rebasedBefore = rebase(source, targetBefore, vec, 47.0)
-    rebasedBefore.toArray should be (Array(47.0, 47.0, 1.0, 2.0))
-    val targetAfter = uniform(ZonedDateTime.of(2015, 4, 11, 0, 0, 0, 0, ZoneId.of("Z")),
+
+    assertRebaser(rebaser(source, targetBefore, 47.0), vec,
+      Array(47.0, 47.0, 1.0, 2.0))
+    assertRebaser(rebaserGeneric(source, targetBefore, 47.0), vec,
+      Array(47.0, 47.0, 1.0, 2.0))
+
+    val targetAfter = uniform(ZonedDateTime.of(2015, 4, 11, 0, 0, 0, 0, Z),
       5,
       new DayFrequency(1))
-    val rebasedAfter = rebase(source, targetAfter, vec, 47.0)
-    rebasedAfter.toArray should be (Array(2.0, 47.0, 3.0, 47.0, 47.0))
+
+    assertRebaser(rebaser(source, targetAfter, 47.0), vec,
+      Array(2.0, 47.0, 3.0, 47.0, 47.0))
+    assertRebaser(rebaserGeneric(source, targetAfter, 47.0), vec,
+      Array(2.0, 47.0, 3.0, 47.0, 47.0))
   }
 
   test("irregular source, source fits in target") {
-    val dt = ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, ZoneId.of("Z"))
+    val dt = ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, Z)
     val source = irregular(Array(dt, dt.plusDays(1), dt.plusDays(3)))
     val target = uniform(dt.minusDays(2), 7, new DayFrequency(1))
     val vec = new DenseVector(Array(1.0, 2.0, 3.0))
-    val rebased = rebase(source, target, vec, 47.0)
-    rebased.toArray should be (Array(47.0, 47.0, 1.0, 2.0, 47.0, 3.0, 47.0))
+
+    assertRebaser(rebaser(source, target, 47.0), vec,
+      Array(47.0, 47.0, 1.0, 2.0, 47.0, 3.0, 47.0))
+    assertRebaser(rebaserGeneric(source, target, 47.0), vec,
+      Array(47.0, 47.0, 1.0, 2.0, 47.0, 3.0, 47.0))
   }
 
   test("irregular source, irregular target") {
@@ -189,7 +212,17 @@ class RebaseSuite extends FunSuite with ShouldMatchers {
       val vec = new DenseVector[Double](source.map(_.toDouble))
       val expectedVec = new DenseVector[Double](expected.map(_.toDouble))
       rebase(sourceIndex, targetIndex, vec, -1) should be (expectedVec)
+      rebaserGeneric(sourceIndex, targetIndex, -1)(vec) should be (expectedVec)
     }
+  }
+
+  private def assertRebaser(
+      rebaser: Rebaser,
+      vec: Vector[Double],
+      expected: Array[Double])
+    : Unit = {
+    val rebased = rebaser(vec)
+    assertArraysEqualWithNaN(rebased.toArray, expected)
   }
 
   private def assertArraysEqualWithNaN(arr1: Array[Double], arr2: Array[Double]): Unit = {

--- a/src/test/scala/com/cloudera/sparkts/RebaseSuite.scala
+++ b/src/test/scala/com/cloudera/sparkts/RebaseSuite.scala
@@ -219,8 +219,7 @@ class RebaseSuite extends FunSuite with ShouldMatchers {
   private def assertRebaser(
       rebaser: Rebaser,
       vec: Vector[Double],
-      expected: Array[Double])
-    : Unit = {
+      expected: Array[Double]): Unit = {
     val rebased = rebaser(vec)
     assertArraysEqualWithNaN(rebased.toArray, expected)
   }


### PR DESCRIPTION
Additions to the public API:
- ```DateTimeIndex``` helper methods
 - ```millisIterator(): Iterator[Long]```
 - ```zonedDateTimeIterator(): Iterator[ZonedDateTime]```

Additions to the private API:
- Generic ```DateTimeIndex``` rebaser at ```TimeSeriesUtils.rebaserGeneric(sourceIndex: DateTimeIndex, targetIndex: DateTimeIndex, defaultValue: Double)```. Helpful for transformations on multiple indices of different types.