### PR TITLE
Add missing copyright headers and fix remaining related warnings

### DIFF
--- a/src/main/java/com/cloudera/sparkts/api/java/DateTimeIndexFactory.java
+++ b/src/main/java/com/cloudera/sparkts/api/java/DateTimeIndexFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (c) 2015, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
 package com.cloudera.sparkts.api.java;
 
 import com.cloudera.sparkts.*;

--- a/src/main/java/com/cloudera/sparkts/api/java/JavaTimeSeriesFactory.java
+++ b/src/main/java/com/cloudera/sparkts/api/java/JavaTimeSeriesFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (c) 2015, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
 package com.cloudera.sparkts.api.java;
 
 import com.cloudera.sparkts.DateTimeIndex;

--- a/src/main/java/com/cloudera/sparkts/api/java/JavaTimeSeriesRDDFactory.java
+++ b/src/main/java/com/cloudera/sparkts/api/java/JavaTimeSeriesRDDFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (c) 2015, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
 package com.cloudera.sparkts.api.java;
 
 import com.cloudera.sparkts.*;

--- a/src/main/scala/com/cloudera/sparkts/api/java/JavaTimeSeries.scala
+++ b/src/main/scala/com/cloudera/sparkts/api/java/JavaTimeSeries.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (c) 2015, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
 package com.cloudera.sparkts.api.java
 
 import java.time.{ZoneId, ZonedDateTime}

--- a/src/main/scala/com/cloudera/sparkts/api/java/JavaTimeSeriesRDD.scala
+++ b/src/main/scala/com/cloudera/sparkts/api/java/JavaTimeSeriesRDD.scala
@@ -1,5 +1,19 @@
-package com.cloudera.sparkts.api.java
+/**
+ * Copyright (c) 2015, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
 
+package com.cloudera.sparkts.api.java
 
 import java.time.ZonedDateTime
 

--- a/src/test/scala/com/cloudera/sparkts/LocalSparkContext.scala
+++ b/src/test/scala/com/cloudera/sparkts/LocalSparkContext.scala
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2015, Cloudera, Inc. All Rights Reserved.
  *
  * Cloudera, Inc. licenses this file to you under the Apache License,

--- a/src/test/scala/com/cloudera/sparkts/stats/TimeSeriesStatisticalTestsSuite.scala
+++ b/src/test/scala/com/cloudera/sparkts/stats/TimeSeriesStatisticalTestsSuite.scala
@@ -3,7 +3,6 @@
  *
  * Cloudera, Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"). You may not use this file except in
- * Version 2.0 (the "License"). You may not use this file except in
  * compliance with the License. You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
@sryza we may have to disable this header check as it doesn't seem to actually accommodate regexes (despite the docs) and we may need to vary this header. Technically speaking not everything in these files is copyright Cloudera; it belongs to respective contributors but is licensed uniformly. 

I wonder if I should change them all to say "Cloudera or respective contributors"?