### PR TITLE
rebaserWithIrregularSource should pass the Timezone of the target ind…

### DIFF
--- a/src/main/scala/com/cloudera/sparkts/TimeSeriesUtils.scala
+++ b/src/main/scala/com/cloudera/sparkts/TimeSeriesUtils.scala
@@ -140,8 +140,9 @@ private[sparkts] object TimeSeriesUtils {
 
     vec: Vector[Double] => {
       val vecRelevant: Iterator[Double] = vec(startLocInSourceVec until vec.length).valuesIterator
-      val iter = iterateWithUniformFrequency(dtsRelevant.map(dts => longToZonedDateTime(dts)).
-        zip(vecRelevant), targetIndex.frequency, defaultValue)
+      val iter = iterateWithUniformFrequency(dtsRelevant.map(dts =>
+        longToZonedDateTime(dts, targetIndex.zone))
+        .zip(vecRelevant), targetIndex.frequency, defaultValue)
 
       val resultArr = new Array[Double](targetIndex.size)
       for (i <- 0 until targetIndex.size) {


### PR DESCRIPTION
…ex when calling longToZonedDateTime rather then allowing system default to be used

This is a regression since introduction of ZonedDateTime