### PR TITLE
Added fill-with-zeros to Fill

### DIFF
--- a/src/main/scala/com/cloudera/sparkts/UnivariateTimeSeries.scala
+++ b/src/main/scala/com/cloudera/sparkts/UnivariateTimeSeries.scala
@@ -145,8 +145,29 @@ object UnivariateTimeSeries {
       case "next" => fillNext(ts)
       case "previous" => fillPrevious(ts)
       case "spline" => fillSpline(ts)
+      case "zero" => fillValue(ts, 0)
       case _ => throw new UnsupportedOperationException()
     }
+  }
+
+  /**
+   * Replace all NaNs with a specific value
+   */
+  def fillValue(values: Array[Double], filler: Double): Array[Double] = {
+    fillValue(new DenseVector(values), filler).data
+  }
+
+  /**
+   * Replace all NaNs with a specific value
+   */
+  def fillValue(values: Vector[Double], filler: Double): DenseVector[Double] = {
+    val result = new DenseVector(values.toArray)
+    var i = 0
+    while (i < result.length) {
+      if (result(i).isNaN) result(i) = filler
+      i += 1
+    }
+    result
   }
 
   def fillNearest(values: Array[Double]): Array[Double] = {


### PR DESCRIPTION
There are use cases where it's useful to fill with zeros, rather than interpolating. For example, if we wish to compute the average volume of trades over the course of a period of time, we should model days for which there is no activity (or NaN) as zero-volume days. 

Changes:
* Added a fillValue method to replace NaNs with a specific value
* Added a 'zero' option to fill to fillWithZeros 

Note: If this is useful, I'll  update docs when I get the word.