### PR TITLE
Union of DateTimeIndex

### DIFF
--- a/src/main/java/com/cloudera/sparkts/api/java/DateTimeIndexFactory.java
+++ b/src/main/java/com/cloudera/sparkts/api/java/DateTimeIndexFactory.java
@@ -139,6 +139,20 @@ public final class DateTimeIndexFactory {
     }
 
     /**
+     * Unions the given indices into a single index at the default date-time zone
+     */
+    public static DateTimeIndex union(DateTimeIndex[] indices) {
+        return DATE_TIME_INDEX.union(indices);
+    }
+
+    /**
+     * Unions the given indices into a single index at the given date-time zone
+     */
+    public static DateTimeIndex union(DateTimeIndex[] indices, ZoneId zone) {
+        return DATE_TIME_INDEX.union(indices, zone);
+    }
+
+    /**
      * Finds the next business day occurring at or after the given date-time.
      */
     public static ZonedDateTime nextBusinessDay(ZonedDateTime dt, int firstDayOfWeek) {

--- a/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
+++ b/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
@@ -483,11 +483,13 @@ class HybridDateTimeIndex(
     val i = binarySearch(0, indices.length - 1, dt)._1
     if (i > -1) {
       val loc = indices(i).locAtDateTime(dt)
-      if (loc >= 0) {
+      if (loc > -1) {
         sizeOnLeft(i) + loc
       } else {
         -1
       }
+    } else {
+      -1
     }
   }
 
@@ -510,6 +512,13 @@ class HybridDateTimeIndex(
     insertionLoc(longToZonedDateTime(dt, dateTimeZone))
   }
 
+  /**
+   * Returns a tuple (a, b):
+   *  a: is the array index of the date-time index that contains the queried date-time dt
+   *     or -1 if dt is not found. This value is used by locAtDateTime method.
+   *  b: is the array index of the date-time index where the queried date-time dt could
+   *     be inserted. This value is used by insertionLoc method.
+   */
   @tailrec
   private def binarySearch(low: Int, high: Int, dt: ZonedDateTime): (Int, Int) = {
     if (low <= high) {

--- a/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
+++ b/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
@@ -722,6 +722,20 @@ object DateTimeIndex {
   }
 
   /**
+   * Unions the given indices into a single index at the default date-time zone
+   */
+  def union(indices: Array[DateTimeIndex]): DateTimeIndex = {
+    DateTimeIndexUtils.union(indices)
+  }
+
+  /**
+   * Unions the given indices into a single index at the given date-time zone
+   */
+  def union(indices: Array[DateTimeIndex], zone: ZoneId): DateTimeIndex = {
+    DateTimeIndexUtils.union(indices, zone)
+  }
+
+  /**
    * Given the ISO index of the day of week, the method returns the day
    * of week index relative to the first day of week i.e. assuming the
    * the first day of week is the base index and has the value of 1

--- a/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
+++ b/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
@@ -107,6 +107,21 @@ trait DateTimeIndex extends Serializable {
   def locAtDateTime(dt: Long): Int
 
   /**
+   * The location at which the given date-time could be inserted. It is the location of the first
+   * date-time that is greater than the given date-time. If the given date-time is greater than
+   * or equal to the last date-time in the index, the index size is returned.
+   */
+  def insertionLoc(dt: ZonedDateTime): Int
+
+  /**
+   * The location at which the given date-time, as milliseconds since the epoch, could be inserted.
+   * It is the location of the first date-time that is greater than the given date-time. If the
+   * given date-time is greater than or equal to the last date-time in the index, the index size
+   * is returned.
+   */
+  def insertionLoc(dt: Long): Int
+
+  /**
    * Returns the contents of the DateTimeIndex as an array of nanosecond values from the epoch.
    */
   def toNanosArray(): Array[Long]
@@ -182,6 +197,25 @@ class UniformDateTimeIndex(
 
   override def locAtDateTime(dt: Long): Int = {
     locAtDateTime(longToZonedDateTime(dt, dateTimeZone))
+  }
+
+  override def insertionLoc(dt: ZonedDateTime): Int = {
+    val loc = frequency.difference(first, dt)
+    if (loc >= 0 && loc < size) {
+      if (dateTimeAtLoc(loc).compareTo(dt) <= 0) {
+        loc + 1
+      } else {
+        loc
+      }
+    } else if (loc < 0) {
+      0
+    } else {
+      size
+    }
+  }
+
+  override def insertionLoc(dt: Long): Int = {
+    insertionLoc(longToZonedDateTime(dt, dateTimeZone))
   }
 
   override def toNanosArray(): Array[Long] = {
@@ -278,6 +312,21 @@ class IrregularDateTimeIndex(
     if (loc < 0) -1 else loc
   }
 
+  override def insertionLoc(dt: ZonedDateTime): Int = {
+    insertionLoc(zonedDateTimeToLong(dt))
+  }
+
+  override def insertionLoc(dt: Long): Int = {
+    var loc = java.util.Arrays.binarySearch(instants, dt)
+    if (loc >= 0) {
+      do loc += 1
+      while (loc < size && instants(loc) == dt)
+      loc
+    } else {
+      -loc - 1
+    }
+  }
+
   override def toNanosArray(): Array[Long] = {
     instants
   }
@@ -334,8 +383,8 @@ class HybridDateTimeIndex(
   override def slice(start: ZonedDateTime, end: ZonedDateTime): HybridDateTimeIndex = {
     require(start.isBefore(end), s"start($start) should be less than end($end)")
 
-    val startIndex = binarySearch(0, indices.length - 1, start)
-    val endIndex = binarySearch(0, indices.length - 1, end)
+    val startIndex = binarySearch(0, indices.length - 1, start)._1
+    val endIndex = binarySearch(0, indices.length - 1, end)._1
 
     val newIndices =
       if (startIndex == endIndex) {
@@ -431,10 +480,8 @@ class HybridDateTimeIndex(
   }
 
   override def locAtDateTime(dt: ZonedDateTime): Int = {
-    val i = binarySearch(0, indices.length - 1, dt)
-    if (i < 0) {
-      -1
-    } else {
+    val i = binarySearch(0, indices.length - 1, dt)._1
+    if (i > -1) {
       val loc = indices(i).locAtDateTime(dt)
       if (loc >= 0) {
         sizeOnLeft(i) + loc
@@ -444,11 +491,27 @@ class HybridDateTimeIndex(
     }
   }
 
-  override def locAtDateTime(dt: Long): Int =
+  override def locAtDateTime(dt: Long): Int = {
     locAtDateTime(longToZonedDateTime(dt, dateTimeZone))
+  }
+
+  override def insertionLoc(dt: ZonedDateTime): Int = {
+    val loc = binarySearch(0, indices.length - 1, dt)._2
+    if (loc >= 0) {
+      sizeOnLeft(loc) + indices(loc).insertionLoc(dt)
+    } else if (dt.isBefore(first)) {
+      0
+    } else {
+      size
+    }
+  }
+
+  override def insertionLoc(dt: Long): Int = {
+    insertionLoc(longToZonedDateTime(dt, dateTimeZone))
+  }
 
   @tailrec
-  private def binarySearch(low: Int, high: Int, dt: ZonedDateTime): Int = {
+  private def binarySearch(low: Int, high: Int, dt: ZonedDateTime): (Int, Int) = {
     if (low <= high) {
       val mid = (low + high) >>> 1
       val midIndex = indices(mid)
@@ -457,10 +520,20 @@ class HybridDateTimeIndex(
       } else if (dt.isAfter(midIndex.last)) {
         binarySearch(mid + 1, high, dt)
       } else {
-        mid
+        (mid, mid)
       }
     } else {
-      -1
+      // if coming from the call "binarySearch(low, mid - 1, dt)"
+      // on the condition "if (dt.isBefore(midIndex.first))"
+      if (high >= 0 && dt.isAfter(indices(high).last)) {
+        (-1, high)
+        // if coming from the call "binarySearch(mid + 1, high, dt)"
+        // on the condition "if (dt.isAfter(midIndex.last))"
+      } else if (low < indices.length && dt.isBefore(indices(low).first)) {
+        (-1, low)
+      } else {
+        (-1, -1)
+      }
     }
   }
 

--- a/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
+++ b/src/main/scala/com/cloudera/sparkts/DateTimeIndex.scala
@@ -140,6 +140,11 @@ trait DateTimeIndex extends Serializable {
    * Returns an iterator over the contents of the DateTimeIndex as ZonedDateTime
    */
   def zonedDateTimeIterator(): Iterator[ZonedDateTime]
+
+  /**
+   * Returns a new DateTimeIndex with instants at the specified zone
+   */
+  def atZone(zone: ZoneId): DateTimeIndex
 }
 
 /**
@@ -256,6 +261,10 @@ class UniformDateTimeIndex(
   override def zonedDateTimeIterator(): Iterator[ZonedDateTime] = {
     (0 until periods).view.map(frequency.advance(start, _)).iterator
   }
+
+  override def atZone(zone: ZoneId): UniformDateTimeIndex = {
+    new UniformDateTimeIndex(start.withZoneSameInstant(zone), periods, frequency, zone)
+  }
 }
 
 /**
@@ -355,6 +364,10 @@ class IrregularDateTimeIndex(
 
   override def zonedDateTimeIterator(): Iterator[ZonedDateTime] = {
     instants.iterator.map(longToZonedDateTime(_, dateTimeZone))
+  }
+
+  override def atZone(zone: ZoneId): IrregularDateTimeIndex = {
+    new IrregularDateTimeIndex(instants, zone)
   }
 }
 
@@ -574,6 +587,10 @@ class HybridDateTimeIndex(
 
   override def zonedDateTimeIterator(): Iterator[ZonedDateTime] = {
     indices.foldLeft(Iterator[ZonedDateTime]())(_ ++ _.zonedDateTimeIterator)
+  }
+
+  override def atZone(zone: ZoneId): HybridDateTimeIndex = {
+    new HybridDateTimeIndex(indices.map(_.atZone(zone)), zone)
   }
 }
 

--- a/src/main/scala/com/cloudera/sparkts/DateTimeIndexUtils.scala
+++ b/src/main/scala/com/cloudera/sparkts/DateTimeIndexUtils.scala
@@ -23,37 +23,57 @@ private[sparkts] object DateTimeIndexUtils {
   implicit val dateTimeIndexOrdering = new Ordering[DateTimeIndex] {
     override def compare(x: DateTimeIndex, y: DateTimeIndex): Int = {
       val c = x.first.compareTo(y.first)
-      if (c == 0) x.size.compareTo(y.size)
-      else c
+      if (c == 0) x.size.compareTo(y.size) else c
     }
   }
 
   /**
-   * indices are sorted and non-overlapping
+   * Given an array of indices that are sorted and non-overlapping,
+   * consecutive two indices a and b are merged into a new index d
+   * according to the following rules:
+   *
+   *  - a and b are both irregular -> d is irregular
+   *  - a and b are both of size 1 -> d is irregular
+   *  - either a is irregular and b is of size 1
+   *    or a is of size 1 and b is irregular -> d is irregular
    */
   def simplify(indices: Array[DateTimeIndex]): Array[DateTimeIndex] = {
     val simplified = new ListBuffer[DateTimeIndex]
-    val accumulator = new ListBuffer[Long]
-    for (i <- 0 until indices.length) {
+
+    // a buffer that holds merge candidates
+    val indexBuffer = new ListBuffer[DateTimeIndex]
+    val lastI = indices.length - 1
+
+    for (i <- 0 to lastI) {
       val currentIndex = indices(i)
-      if (currentIndex.isInstanceOf[IrregularDateTimeIndex]) {
-        accumulator ++= currentIndex.asInstanceOf[IrregularDateTimeIndex].instants
-      } else if (currentIndex.size == 1 && !currentIndex.isInstanceOf[IrregularDateTimeIndex]) {
-        accumulator += TimeSeriesUtils.zonedDateTimeToLong(currentIndex.first)
-      } else {
-        if (accumulator.size > 0) {
-          val newIndex = new IrregularDateTimeIndex(accumulator.toArray, indices(i - 1).zone)
-          simplified += newIndex
-          accumulator.clear()
+      val isAMergeCandidate = currentIndex.size == 1 ||
+        currentIndex.isInstanceOf[IrregularDateTimeIndex]
+
+      // if currentIndex is a merge candidate -> append to the buffer
+      if (isAMergeCandidate) {
+        indexBuffer += currentIndex
+      }
+
+      // if the contiguous sequence of merge candidates, if any
+      // , is broken by a non-merge candidate or we are at the
+      // end of the loop
+      if (!isAMergeCandidate || i == lastI) {
+        // more than one merge candidate -> do the merge
+        if (indexBuffer.length > 1) {
+          simplified += new IrregularDateTimeIndex(
+            indexBuffer.map(_.toNanosArray).reduce(_ ++ _),
+            indexBuffer.head.zone)
+          indexBuffer.clear()
+        // only one merge candidate -> no merge
+        } else if (indexBuffer.length == 1) {
+          simplified += indexBuffer.head
+          indexBuffer.clear()
         }
-        simplified += currentIndex
+
+        if (!isAMergeCandidate) simplified += currentIndex
       }
     }
-    if (accumulator.size > 0) {
-      val newIndex = new IrregularDateTimeIndex(accumulator.toArray, indices.last.zone)
-      simplified += newIndex
-      accumulator.clear()
-    }
+
     simplified.toArray
   }
   

--- a/src/main/scala/com/cloudera/sparkts/DateTimeIndexUtils.scala
+++ b/src/main/scala/com/cloudera/sparkts/DateTimeIndexUtils.scala
@@ -1,0 +1,78 @@
+package com.cloudera.sparkts
+
+import java.time.ZoneId
+
+import scala.collection.mutable.{ListBuffer, PriorityQueue}
+
+private[sparkts] object DateTimeIndexUtils {
+  implicit val dateTimeIndexOrdering = new Ordering[DateTimeIndex] {
+    override def compare(x: DateTimeIndex, y: DateTimeIndex): Int = {
+      val c = x.first.compareTo(y.first)
+      if (c == 0) x.size.compareTo(y.size)
+      else c
+    }
+  }
+
+  /**
+   * indices are sorted and non-overlapping
+   */
+  def simplify(indices: Array[DateTimeIndex]): Array[DateTimeIndex] = {
+    val simplified = new ListBuffer[DateTimeIndex]
+    val accumulator = new ListBuffer[Long]
+    for (i <- 0 until indices.length) {
+      val currentIndex = indices(i)
+      if (currentIndex.isInstanceOf[IrregularDateTimeIndex]) {
+        accumulator ++= currentIndex.asInstanceOf[IrregularDateTimeIndex].instants
+      } else {
+        if (accumulator.size > 0) {
+          val newIndex = new IrregularDateTimeIndex(accumulator.toArray, indices(i - 1).zone)
+          simplified += newIndex
+          accumulator.clear()
+        }
+        simplified += currentIndex
+      }
+    }
+    simplified.toArray
+  }
+  
+  def union(indices: Array[DateTimeIndex], zone: ZoneId = ZoneId.systemDefault())
+    : DateTimeIndex = {
+    val indicesPQ = new PriorityQueue[DateTimeIndex]()
+    indices.foreach(indicesPQ.enqueue(_))
+
+    val unionList = new ListBuffer[DateTimeIndex]
+    unionList += indicesPQ.dequeue
+
+    while (!indicesPQ.isEmpty) {
+      val a = unionList.remove(unionList.length - 1)
+      var b = indicesPQ.dequeue
+      
+      var isBTrimmed = false
+      while (a.locAtDateTime(b.first) > -1) {
+        b = b.islice(1, b.size)
+        isBTrimmed = true
+      }
+      
+      if (isBTrimmed && b.size > 0) {
+        unionList += a
+        indicesPQ.enqueue(b)
+      } else {
+        val splitLoc = a.insertionLoc(b.first)
+        if (splitLoc < a.size) {
+          val aLower = a.islice(0, splitLoc)
+          val aUpper = a.islice(splitLoc, a.size)
+          unionList += aLower
+          unionList += b
+          indicesPQ.enqueue(aUpper)
+        } else {
+          unionList += a
+          unionList += b
+        }
+      }
+    }
+
+    val simplified = simplify(unionList.toArray)
+    
+    new HybridDateTimeIndex(simplified)
+  }
+}

--- a/src/main/scala/com/cloudera/sparkts/DateTimeIndexUtils.scala
+++ b/src/main/scala/com/cloudera/sparkts/DateTimeIndexUtils.scala
@@ -149,6 +149,6 @@ private[sparkts] object DateTimeIndexUtils {
 
     val simplified = simplify(unionList.toArray)
     
-    new HybridDateTimeIndex(simplified, zone)
+    new HybridDateTimeIndex(simplified).atZone(zone)
   }
 }

--- a/src/test/scala/com/cloudera/sparkts/DateTimeIndexSuite.scala
+++ b/src/test/scala/com/cloudera/sparkts/DateTimeIndexSuite.scala
@@ -98,6 +98,12 @@ class DateTimeIndexSuite extends FunSuite with ShouldMatchers {
 
     index.nanosIterator.toArray should be (index.toNanosArray)
     index.zonedDateTimeIterator.toArray should be (index.toZonedDateTimeArray)
+
+    index.insertionLoc(ZonedDateTime.of(2015, 4, 9, 0, 0, 0, 0, UTC)) should be (0)
+    index.insertionLoc(ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, UTC)) should be (1)
+    index.insertionLoc(ZonedDateTime.of(2015, 4, 11, 0, 0, 0, 0, UTC)) should be (1)
+    index.insertionLoc(ZonedDateTime.of(2015, 4, 12, 0, 0, 0, 0, UTC)) should be (2)
+    index.insertionLoc(index.last) should be (index.size)
   }
 
   test("irregular") {
@@ -130,6 +136,12 @@ class DateTimeIndexSuite extends FunSuite with ShouldMatchers {
 
     index.nanosIterator.toArray should be (index.toNanosArray)
     index.zonedDateTimeIterator.toArray should be (index.toZonedDateTimeArray)
+
+    index.insertionLoc(ZonedDateTime.of(2015, 4, 13, 0, 0, 0, 0, UTC)) should be (0)
+    index.insertionLoc(ZonedDateTime.of(2015, 4, 14, 0, 0, 0, 0, UTC)) should be (1)
+    index.insertionLoc(ZonedDateTime.of(2015, 4, 15, 0, 0, 0, 0, UTC)) should be (2)
+    index.insertionLoc(ZonedDateTime.of(2015, 4, 16, 0, 0, 0, 0, UTC)) should be (2)
+    index.insertionLoc(index.last) should be (index.size)
     // TODO: test bounds that aren't members of the index
   }
 
@@ -216,6 +228,20 @@ class DateTimeIndexSuite extends FunSuite with ShouldMatchers {
 
     index.nanosIterator.toArray should be (index.toNanosArray)
     index.zonedDateTimeIterator.toArray should be (index.toZonedDateTimeArray)
+
+    index.insertionLoc(ZonedDateTime.of(2015, 4, 9, 0, 0, 0, 0, UTC)) should be (0)
+    index.insertionLoc(ZonedDateTime.of(2015, 4, 10, 0, 0, 0, 0, UTC)) should be (1)
+    index.insertionLoc(ZonedDateTime.of(2015, 4, 11, 0, 0, 0, 0, UTC)) should be (1)
+    index.insertionLoc(ZonedDateTime.of(2015, 4, 18, 0, 0, 0, 0, UTC)) should be (5)
+    index.insertionLoc(ZonedDateTime.of(2015, 4, 19, 0, 0, 0, 0, UTC)) should be (6)
+    index.insertionLoc(ZonedDateTime.of(2015, 4, 22, 0, 0, 0, 0, UTC)) should be (8)
+    index.insertionLoc(ZonedDateTime.of(2015, 4, 28, 0, 0, 0, 0, UTC)) should be (10)
+    index.insertionLoc(ZonedDateTime.of(2015, 4, 29, 0, 0, 0, 0, UTC)) should be (10)
+    index.insertionLoc(ZonedDateTime.of(2015, 5, 9, 0, 0, 0, 0, UTC)) should be (10)
+    index.insertionLoc(ZonedDateTime.of(2015, 5, 10, 0, 0, 0, 0, UTC)) should be (11)
+    index.insertionLoc(ZonedDateTime.of(2015, 5, 11, 0, 0, 0, 0, UTC)) should be (11)
+    index.insertionLoc(ZonedDateTime.of(2015, 5, 18, 0, 0, 0, 0, UTC)) should be (15)
+    index.insertionLoc(ZonedDateTime.of(2015, 5, 19, 0, 0, 0, 0, UTC)) should be (15)
   }
 
   test("rebased day of week") {

--- a/src/test/scala/com/cloudera/sparkts/DateTimeIndexUtilsSuite.scala
+++ b/src/test/scala/com/cloudera/sparkts/DateTimeIndexUtilsSuite.scala
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2015, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.cloudera.sparkts
+
+import java.time.{Period, ZonedDateTime, ZoneId}
+
+import com.cloudera.sparkts.DateTimeIndex._
+import com.cloudera.sparkts.DateTimeIndexUtils._
+import org.scalatest.{FunSuite, ShouldMatchers}
+
+class DateTimeIndexUtilsSuite extends FunSuite with ShouldMatchers {
+  val UTC = ZoneId.of("Z")
+
+  test("non-overlapping sorted") {
+    val index1: DateTimeIndex = uniform(dt("2015-04-10"), 5, new DayFrequency(2), UTC)
+    val index2: DateTimeIndex = uniform(dt("2015-05-10"), 5, new DayFrequency(2), UTC)
+    val index3: DateTimeIndex = irregular(Array(
+      dt("2015-06-10"),
+      dt("2015-06-13"),
+      dt("2015-06-15"),
+      dt("2015-06-20"),
+      dt("2015-06-25")
+    ), UTC)
+
+    union(Array(index1, index2, index3), UTC) should be (
+      hybrid(Array(index1, index2, index3), UTC))
+  }
+
+  test("non-overlapping non-sorted") {
+    val index1: DateTimeIndex = uniform(dt("2015-04-10"), 5, new DayFrequency(2), UTC)
+    val index2: DateTimeIndex = uniform(dt("2015-05-10"), 5, new DayFrequency(2), UTC)
+    val index3: DateTimeIndex = irregular(Array(
+      dt("2015-06-10"),
+      dt("2015-06-13"),
+      dt("2015-06-15"),
+      dt("2015-06-20"),
+      dt("2015-06-25")
+    ), UTC)
+
+    union(Array(index3, index1, index2), UTC) should be (
+      hybrid(Array(index1, index2, index3), UTC))
+  }
+
+  test("overlapping uniform and irregular") {
+    val index1: DateTimeIndex = uniform(dt("2015-04-10"), 5, new DayFrequency(2), UTC)
+    val index2: DateTimeIndex = uniform(dt("2015-05-10"), 5, new DayFrequency(2), UTC)
+    val index3: DateTimeIndex = irregular(Array(
+      dt("2015-04-09"),
+      dt("2015-04-11"),
+      dt("2015-05-01"),
+      dt("2015-05-10"),
+      dt("2015-06-25")
+    ), UTC)
+
+    union(Array(index3, index1, index2), UTC) should be (
+      hybrid(Array(
+        irregular(Array(
+          dt("2015-04-09"),
+          dt("2015-04-10"),
+          dt("2015-04-11")), UTC),
+        uniform(dt("2015-04-12"), 4, new DayFrequency(2), UTC),
+        irregular(Array(dt("2015-05-01"),
+          dt("2015-05-10")), UTC),
+        uniform(dt("2015-05-12"), 4, new DayFrequency(2), UTC),
+        irregular(Array(dt("2015-06-25")), UTC)
+      ), UTC))
+  }
+
+  def dt(dt: String, zone: ZoneId = UTC): ZonedDateTime = {
+    val splits = dt.split("-").map(_.toInt)
+    ZonedDateTime.of(splits(0), splits(1), splits(2), 0, 0, 0, 0, zone)
+  }
+}

--- a/src/test/scala/com/cloudera/sparkts/DateTimeIndexUtilsSuite.scala
+++ b/src/test/scala/com/cloudera/sparkts/DateTimeIndexUtilsSuite.scala
@@ -18,7 +18,6 @@ package com.cloudera.sparkts
 import java.time.{ZonedDateTime, ZoneId}
 
 import com.cloudera.sparkts.DateTimeIndex._
-import com.cloudera.sparkts.DateTimeIndexUtils._
 import org.scalatest.{FunSuite, ShouldMatchers}
 
 class DateTimeIndexUtilsSuite extends FunSuite with ShouldMatchers {
@@ -35,7 +34,7 @@ class DateTimeIndexUtilsSuite extends FunSuite with ShouldMatchers {
       dt("2015-06-25")
     ), UTC)
 
-    union(Array(index1, index2, index3), UTC) should be (
+    DateTimeIndexUtils.union(Array(index1, index2, index3), UTC) should be (
       hybrid(Array(index1, index2, index3)))
   }
 
@@ -50,7 +49,7 @@ class DateTimeIndexUtilsSuite extends FunSuite with ShouldMatchers {
       dt("2015-06-25")
     ), UTC)
 
-    union(Array(index3, index1, index2), UTC) should be (
+    DateTimeIndexUtils.union(Array(index3, index1, index2), UTC) should be (
       hybrid(Array(index1, index2, index3)))
   }
 
@@ -65,7 +64,7 @@ class DateTimeIndexUtilsSuite extends FunSuite with ShouldMatchers {
       dt("2015-06-25")
     ), UTC)
 
-    union(Array(index3, index1, index2), UTC) should be (
+    DateTimeIndexUtils.union(Array(index3, index1, index2), UTC) should be (
       hybrid(Array(
         irregular(Array(
           dt("2015-04-09"),

--- a/src/test/scala/com/cloudera/sparkts/DateTimeIndexUtilsSuite.scala
+++ b/src/test/scala/com/cloudera/sparkts/DateTimeIndexUtilsSuite.scala
@@ -15,7 +15,7 @@
 
 package com.cloudera.sparkts
 
-import java.time.{Period, ZonedDateTime, ZoneId}
+import java.time.{ZonedDateTime, ZoneId}
 
 import com.cloudera.sparkts.DateTimeIndex._
 import com.cloudera.sparkts.DateTimeIndexUtils._
@@ -36,7 +36,7 @@ class DateTimeIndexUtilsSuite extends FunSuite with ShouldMatchers {
     ), UTC)
 
     union(Array(index1, index2, index3), UTC) should be (
-      hybrid(Array(index1, index2, index3), UTC))
+      hybrid(Array(index1, index2, index3)))
   }
 
   test("non-overlapping non-sorted") {
@@ -51,7 +51,7 @@ class DateTimeIndexUtilsSuite extends FunSuite with ShouldMatchers {
     ), UTC)
 
     union(Array(index3, index1, index2), UTC) should be (
-      hybrid(Array(index1, index2, index3), UTC))
+      hybrid(Array(index1, index2, index3)))
   }
 
   test("overlapping uniform and irregular") {
@@ -76,7 +76,7 @@ class DateTimeIndexUtilsSuite extends FunSuite with ShouldMatchers {
           dt("2015-05-10")), UTC),
         uniform(dt("2015-05-12"), 4, new DayFrequency(2), UTC),
         irregular(Array(dt("2015-06-25")), UTC)
-      ), UTC))
+      )))
   }
 
   def dt(dt: String, zone: ZoneId = UTC): ZonedDateTime = {


### PR DESCRIPTION
Additions to the public API:
- ```DateTimeIndex``` helper methods
 - ```insertionLoc``` methods to find the location at which the given date-time could be inserted. It is the location of the first date-time that is greater than the given date-time. If the given date-time is greater than or equal to the last date-time in the index, the index size is returned. Used in transformations on multiple indices.
 - ```atZone(zone: ZoneId)``` adjusts the time zone of the index.  Used in transformations on multiple indices.
- Methods added to ```DateTimeIndex``` object
 - ```union``` multiple date-time indices into one date-time index.

Additions to the private API:
- ```DateTimeIndexUtils``` object holds utilities methods of the ```DateTimeIndex```
 - ```dateTimeIndexOrdering``` defines an ordering on ```DateTimeIndex``` s.t. for two ```DateTimeIndex``` ```x``` and ```y```, ```x < y iff x.first < y.first || (x.first == y.first && x.size < y.size)```
 - ```simplify(indices: Array[DateTimeIndex]): Array[DateTimeIndex]``` merges contiguous indices as possible
 - ```union``` unions a list of indices into one ```DateTimeIndex```
